### PR TITLE
camelsus read forcing data only once

### DIFF
--- a/neuralhydrology/datasetzoo/camelsus.py
+++ b/neuralhydrology/datasetzoo/camelsus.py
@@ -209,7 +209,7 @@ def load_camels_us_discharge(data_dir: Path, basin: str, area: int) -> pd.Series
     """
 
     discharge_path = data_dir / 'usgs_streamflow'
-    file_path = list(discharge_path.glob(f'**/{basin}_*_streamflow_qc.txt'))
+    file_path = list(discharge_path.glob(f'**/{basin}_streamflow_qc.txt'))
     if file_path:
         file_path = file_path[0]
     else:


### PR DESCRIPTION
By reading the header and dataframe from the same file pointer.

Also avoids manually filtering the paths from glob, by adding the basin to the glob string.
