### PR TITLE
Implement peak flow bias metric

### DIFF
--- a/neuralhydrology/evaluation/metrics.py
+++ b/neuralhydrology/evaluation/metrics.py
@@ -651,12 +651,20 @@ def peak_flow_bias(obs: DataArray,
     # get time series with only valid observations
     obs, sim = _mask_valid(obs, sim)
 
+    # return np.nan if there are no valid observed or simulated values
+    if obs.size == 0 or sim.size == 0:
+        return np.nan
+
     # heuristic to get indices of peaks and their corresponding height.
     peaks, _ = signal.find_peaks(obs.values, distance=100, prominence=np.std(obs.values))
 
+    # check if any peaks exist, otherwise return np.nan
+    if peaks.size == 0:
+        return np.nan
+
     # subset data to only peak values
-    obs = obs[peaks]
-    sim = sim[peaks]
+    obs = obs[peaks].values
+    sim = sim[peaks].values
 
     # calculate the peak error
     peak_error = np.sum(sim - obs) / np.sum(obs)


### PR DESCRIPTION
This pull request introduces a new metric that calculates a peak bias error in percent. The metric takes into account the shortcoming of the $\text{BiasFHV}$, which has been discussed [here](https://github.com/neuralhydrology/neuralhydrology/discussions/94).

The implementation is based on the mean peak timing metric implementation, with the difference that it does not calculates the temporal peak difference, but the bias of observed and simulated peak values in percent.