### PR TITLE
Enable predictions in basins with no observations

### DIFF
--- a/neuralhydrology/datasetzoo/basedataset.py
+++ b/neuralhydrology/datasetzoo/basedataset.py
@@ -232,6 +232,13 @@ class BaseDataset(Dataset):
                 df[f"{feature}_copy{n}"] = df[feature]
 
         return df
+    
+    def _add_missing_targets(self, df: pd.DataFrame) -> pd.DataFrame:
+        for var in self.cfg.target_variables:
+            if var not in df.columns:
+                df[var] = np.nan
+
+        return df
 
     def _add_lagged_features(self, df: pd.DataFrame) -> pd.DataFrame:
 
@@ -290,6 +297,9 @@ class BaseDataset(Dataset):
 
                 # add columns from dataframes passed as additional data files
                 df = pd.concat([df, *[d[basin] for d in self.additional_features]], axis=1)
+
+                # if target variables are missing for basin, add empty column to still allow predictions to be made
+                df = self._add_missing_targets(df)
 
                 # check if any feature should be duplicated
                 df = self._duplicate_features(df)

--- a/neuralhydrology/datasetzoo/basedataset.py
+++ b/neuralhydrology/datasetzoo/basedataset.py
@@ -299,7 +299,8 @@ class BaseDataset(Dataset):
                 df = pd.concat([df, *[d[basin] for d in self.additional_features]], axis=1)
 
                 # if target variables are missing for basin, add empty column to still allow predictions to be made
-                df = self._add_missing_targets(df)
+                if not self.is_train:
+                    df = self._add_missing_targets(df)
 
                 # check if any feature should be duplicated
                 df = self._duplicate_features(df)


### PR DESCRIPTION
Per discussion #107 , this PR will help make it easier to still be able to make predictions in a basin where there are no observations available. 

Have implemented in the `basedataset` so all datasets can utilize the feature. But will note this wouldn't prevent an individual dataset class from erroring if it is setup to check for missing streamflow files (such as with `CAMELS_US`). Overall, adds a little flexibility though.

For making predictions in ungaged locations or when no observations are available it would still be nice to have something a little more separate in neuralhydrology for a "predict mode".  One way I could see implementing that without a significant new component would be to add a "predict" (or similarly named) basin file and date range option in the config in addition to "train, validation, and test". Could then have a `start_prediction` under `nh.evaluation` that calls evaluate but without any metrics. So, adding a `predict_run` entry point. Probably, a little better option would be to have a whole separate `nh.prediction` component, but that is probably a little work to setup. I could likely spend some time on this if there was a direction that made sense to you all to implement and either add it to this draft PR or open a new one.

