### PR TITLE
Enable non-verbose mode in trainer and tester

### DIFF
--- a/neuralhydrology/evaluation/tester.py
+++ b/neuralhydrology/evaluation/tester.py
@@ -64,6 +64,8 @@ class BaseTester(object):
         if self.init_model:
             self.model = get_model(cfg).to(self.device)
 
+        self._disable_pbar = cfg.verbose == 0
+
         # pre-initialize variables, defined in class methods
         self.basins = None
         self.scaler = None
@@ -190,7 +192,7 @@ class BaseTester(object):
 
         results = defaultdict(dict)
 
-        pbar = tqdm(basins, file=sys.stdout)
+        pbar = tqdm(basins, file=sys.stdout, disable=self._disable_pbar)
         pbar.set_description('# Validation' if self.period == "validation" else "# Evaluation")
 
         for basin in pbar:

--- a/neuralhydrology/training/basetrainer.py
+++ b/neuralhydrology/training/basetrainer.py
@@ -50,6 +50,7 @@ class BaseTrainer(object):
         self._target_std = None
         self._scaler = {}
         self._allow_subsequent_nan_losses = cfg.allow_subsequent_nan_losses
+        self._disable_pbar = cfg.verbose == 0
 
         # load train basin list and add number of basins to the config
         self.basins = load_basin_file(cfg.train_basin_file)
@@ -273,7 +274,7 @@ class BaseTrainer(object):
         self.experiment_logger.train()
 
         # process bar handle
-        pbar = tqdm(self.loader, file=sys.stdout)
+        pbar = tqdm(self.loader, file=sys.stdout, disable=self._disable_pbar)
         pbar.set_description(f'# Epoch {epoch}')
 
         # Iterate in batches over training set


### PR DESCRIPTION
It looks to me like the `verbose` config argument is only implemented in the `BaseDataset`. For running models in a computing environment that generates log files, having the progress bar enables results in a lot of output in the log file!

This PR just adds passing the `verbose` config argument to the `disable` parameter when calling `tqdm` in the `BaseTrainer` and `BaseTester` classes so that all progress bar activity is disabled when `verbose: 0`