### PR TITLE
Implemented the Mamba State Space model

### DIFF
--- a/docs/source/api/neuralhydrology.modelzoo.mamba.rst
+++ b/docs/source/api/neuralhydrology.modelzoo.mamba.rst
@@ -1,0 +1,7 @@
+Mamba
+===
+
+.. automodule:: neuralhydrology.modelzoo.mamba
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/neuralhydrology.modelzoo.mamba.rst
+++ b/docs/source/api/neuralhydrology.modelzoo.mamba.rst
@@ -1,5 +1,5 @@
 Mamba
-===
+=====
 
 .. automodule:: neuralhydrology.modelzoo.mamba
    :members:

--- a/docs/source/api/neuralhydrology.modelzoo.rst
+++ b/docs/source/api/neuralhydrology.modelzoo.rst
@@ -20,6 +20,7 @@ nh.modelzoo
    neuralhydrology.modelzoo.handoff_forecast_lstm
    neuralhydrology.modelzoo.head
    neuralhydrology.modelzoo.inputlayer
+   neuralhydrology.modelzoo.mamba
    neuralhydrology.modelzoo.mclstm
    neuralhydrology.modelzoo.multihead_forecast_lstm
    neuralhydrology.modelzoo.mtslstm

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -225,6 +225,14 @@ These are used if ``model == mtslstm``.
    current input timescale. In both cases, ``transfer_mtslstm_states``
    can be used to configure hidden and cell state transfer.
 
+Mamba settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These are used if ``model == mamba``.
+
+-  ``mamba_d_conv``: Local convolution width
+-  ``mamba_d_state``: State Space Model state expansion factor
+-  ``mamba_expand``: Block expansion factor
+
 Transformer settings
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -226,7 +226,7 @@ These are used if ``model == mtslstm``.
    can be used to configure hidden and cell state transfer.
 
 Mamba settings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~
 These are used if ``model == mamba``.
 
 -  ``mamba_d_conv``: Local convolution width

--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -103,11 +103,11 @@ being concatenated.
 
 Mamba
 ^^^^^
-:py:class:`neuralhydrology.modelzoo.mamba.Mamba` is a state space model SSM using the PyTorch implementation
+:py:class:`neuralhydrology.modelzoo.mamba.Mamba` is a state space model (SSM) using the PyTorch implementation
 https://github.com/state-spaces/mamba/tree/main from `Gu and Dao (2023) <https://arxiv.org/abs/2312.00752>`_.
 
 There are two required dependencies for Mamba: ``mamba_ssm`` and ``causal-conv1d``, which are the mamba ssm layer and
-implementation of a simple causal Conv1d layer used inside the Mamba block, respectively.
+implementation of a simple causal Conv1d layer used inside the Mamba block, respectively. Note the version here: ``causal-conv1d>=1.1.0``
 
 There are three hyperparameters which can be set in the config file:
 - ``mamba_d_conv``: Local convolution width (Default is set to 4)

--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -101,6 +101,19 @@ being concatenated.
 
 .. _MC-LSTM:
 
+Mamba
+^^^^^
+:py:class:`neuralhydrology.modelzoo.mamba.Mamba` is a state space model SSM using the PyTorch implementation
+https://github.com/state-spaces/mamba/tree/main from `Gu and Dao (2023) <https://arxiv.org/abs/2312.00752>`_.
+
+There are two required dependencies for Mamba: ``mamba_ssm`` and ``causal-conv1d``, which are the mamba ssm layer and
+implementation of a simple causal Conv1d layer used inside the Mamba block, respectively.
+
+There are three hyperparameters which can be set in the config file:
+- ``mamba_d_conv``: Local convolution width (Default is set to 4)
+- ``mamba_d_state``: SSM state expansion factor (Default is set to 16)
+- ``mamba_expand``: Block expansion factor (Default is set to 2)
+
 MC-LSTM
 ^^^^^^^
 :py:class:`neuralhydrology.modelzoo.mclstm.MCLSTM` is a concept for a mass-conserving model architecture inspired by the

--- a/neuralhydrology/modelzoo/__init__.py
+++ b/neuralhydrology/modelzoo/__init__.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 
 from neuralhydrology.modelzoo.arlstm import ARLSTM
 from neuralhydrology.modelzoo.cudalstm import CudaLSTM
-from neuralhydrology.modelzoo.mamba import CudaMamba
+from neuralhydrology.modelzoo.mamba import Mamba
 from neuralhydrology.modelzoo.customlstm import CustomLSTM
 from neuralhydrology.modelzoo.ealstm import EALSTM
 from neuralhydrology.modelzoo.embcudalstm import EmbCudaLSTM

--- a/neuralhydrology/modelzoo/__init__.py
+++ b/neuralhydrology/modelzoo/__init__.py
@@ -21,12 +21,12 @@ from neuralhydrology.utils.config import Config
 
 SINGLE_FREQ_MODELS = [
     "cudalstm",
-    "cudamamba",
     "ealstm", 
     "customlstm", 
     "embcudalstm", 
     "gru", 
-    "transformer", 
+    "transformer",
+    "mamba",
     "mclstm", 
     "arlstm",
     "handoff_forecast_lstm",
@@ -63,8 +63,6 @@ def get_model(cfg: Config) -> nn.Module:
         model = ARLSTM(cfg=cfg)
     elif cfg.model.lower() == "cudalstm":
         model = CudaLSTM(cfg=cfg)
-    elif cfg.model.lower() == "mamba":
-        model = Mamba(cfg=cfg)
     elif cfg.model.lower() == "ealstm":
         model = EALSTM(cfg=cfg)
     elif cfg.model.lower() == "customlstm":
@@ -86,6 +84,8 @@ def get_model(cfg: Config) -> nn.Module:
         model = MCLSTM(cfg=cfg)
     elif cfg.model.lower() == "transformer":
         model = Transformer(cfg=cfg)
+    elif cfg.model.lower() == "mamba":
+        model = Mamba(cfg=cfg)
     elif cfg.model.lower() == "handoff_forecast_lstm":
         model = HandoffForecastLSTM(cfg=cfg)
     elif cfg.model.lower() == "multihead_forecast_lstm":

--- a/neuralhydrology/modelzoo/__init__.py
+++ b/neuralhydrology/modelzoo/__init__.py
@@ -64,7 +64,7 @@ def get_model(cfg: Config) -> nn.Module:
     elif cfg.model.lower() == "cudalstm":
         model = CudaLSTM(cfg=cfg)
     elif cfg.model.lower() == "cudamamba":
-        model = CudaLSTM(cfg=cfg)
+        model = CudaMamba(cfg=cfg)
     elif cfg.model.lower() == "ealstm":
         model = EALSTM(cfg=cfg)
     elif cfg.model.lower() == "customlstm":

--- a/neuralhydrology/modelzoo/__init__.py
+++ b/neuralhydrology/modelzoo/__init__.py
@@ -4,6 +4,7 @@ import torch.nn as nn
 
 from neuralhydrology.modelzoo.arlstm import ARLSTM
 from neuralhydrology.modelzoo.cudalstm import CudaLSTM
+from neuralhydrology.modelzoo.cudamamba import CudaMamba
 from neuralhydrology.modelzoo.customlstm import CustomLSTM
 from neuralhydrology.modelzoo.ealstm import EALSTM
 from neuralhydrology.modelzoo.embcudalstm import EmbCudaLSTM
@@ -19,7 +20,8 @@ from neuralhydrology.modelzoo.transformer import Transformer
 from neuralhydrology.utils.config import Config
 
 SINGLE_FREQ_MODELS = [
-    "cudalstm", 
+    "cudalstm",
+    "cudamamba",
     "ealstm", 
     "customlstm", 
     "embcudalstm", 
@@ -60,6 +62,8 @@ def get_model(cfg: Config) -> nn.Module:
     if cfg.model.lower() == "arlstm":
         model = ARLSTM(cfg=cfg)
     elif cfg.model.lower() == "cudalstm":
+        model = CudaLSTM(cfg=cfg)
+    elif cfg.model.lower() == "cudamamba":
         model = CudaLSTM(cfg=cfg)
     elif cfg.model.lower() == "ealstm":
         model = EALSTM(cfg=cfg)

--- a/neuralhydrology/modelzoo/__init__.py
+++ b/neuralhydrology/modelzoo/__init__.py
@@ -4,7 +4,7 @@ import torch.nn as nn
 
 from neuralhydrology.modelzoo.arlstm import ARLSTM
 from neuralhydrology.modelzoo.cudalstm import CudaLSTM
-from neuralhydrology.modelzoo.cudamamba import CudaMamba
+from neuralhydrology.modelzoo.mamba import CudaMamba
 from neuralhydrology.modelzoo.customlstm import CustomLSTM
 from neuralhydrology.modelzoo.ealstm import EALSTM
 from neuralhydrology.modelzoo.embcudalstm import EmbCudaLSTM
@@ -63,8 +63,8 @@ def get_model(cfg: Config) -> nn.Module:
         model = ARLSTM(cfg=cfg)
     elif cfg.model.lower() == "cudalstm":
         model = CudaLSTM(cfg=cfg)
-    elif cfg.model.lower() == "cudamamba":
-        model = CudaMamba(cfg=cfg)
+    elif cfg.model.lower() == "mamba":
+        model = Mamba(cfg=cfg)
     elif cfg.model.lower() == "ealstm":
         model = EALSTM(cfg=cfg)
     elif cfg.model.lower() == "customlstm":

--- a/neuralhydrology/modelzoo/cudamamba.py
+++ b/neuralhydrology/modelzoo/cudamamba.py
@@ -64,8 +64,11 @@ class CudaMamba(BaseModel):
         """
         # possibly pass dynamic and static inputs through embedding layers, then concatenate them
         x_d = self.embedding_net(data)
-        y_hat = self.mamba(x_d)
-        pred = {'y_hat': y_hat}
-        pred.update(self.head(self.dropout(y_hat)))
+        mamba_output = self.mamba(x_d)
 
+        # reshape to [batch_size, seq, n_hiddens]
+        mamba_output = mamba_output.transpose(0, 1)
+
+        pred = {'y_hat': mamba_output}
+        pred.update(self.head(self.dropout(mamba_output)))
         return pred

--- a/neuralhydrology/modelzoo/cudamamba.py
+++ b/neuralhydrology/modelzoo/cudamamba.py
@@ -64,7 +64,13 @@ class CudaMamba(BaseModel):
         """
         # possibly pass dynamic and static inputs through embedding layers, then concatenate them
         x_d = self.embedding_net(data)
+
+        # mamba expects:
+        # hidden_states: (B, L, D)
+        # batch, seqlen, dim = hidden_states.shape
+        x_d = x_d.transpose(1, 2)
         mamba_output = self.mamba(x_d)
+        mamba_output = mamba_output.transpose(1, 2)
 
         # reshape to [batch_size, seq, n_hiddens]
         mamba_output = mamba_output.transpose(0, 1)

--- a/neuralhydrology/modelzoo/cudamamba.py
+++ b/neuralhydrology/modelzoo/cudamamba.py
@@ -1,0 +1,71 @@
+from typing import Dict
+
+from mamba_ssm import Mamba
+import torch
+import torch.nn as nn
+
+from neuralhydrology.modelzoo.inputlayer import InputLayer
+from neuralhydrology.modelzoo.head import get_head
+from neuralhydrology.modelzoo.basemodel import BaseModel
+from neuralhydrology.utils.config import Config
+
+
+class CudaMamba(BaseModel):
+    """LSTM model class, which relies on PyTorch's CUDA LSTM class.
+
+    This class implements the standard LSTM combined with a model head, as specified in the config. Depending on the
+    embedding settings, static and/or dynamic features may or may not be fed through embedding networks before being
+    concatenated and passed through the LSTM.
+    To control the initial forget gate bias, use the config argument `initial_forget_bias`. Often it is useful to set
+    this value to a positive value at the start of the model training, to keep the forget gate closed and to facilitate
+    the gradient flow.
+    The `CudaLSTM` class only supports single-timescale predictions. Use `MTSLSTM` to train a model and get
+    predictions on multiple temporal resolutions at the same time.
+
+    Parameters
+    ----------
+    cfg : Config
+        The run configuration.
+    """
+    # specify submodules of the model that can later be used for finetuning. Names must match class attributes
+    module_parts = ['embedding_net', 'lstm', 'head']
+
+    def __init__(self, cfg: Config):
+        super(CudaMamba, self).__init__(cfg=cfg)
+
+        self.embedding_net = InputLayer(cfg)
+
+        self.mamba = Mamba(
+            d_model=self.cfg.hidden_size,
+            d_state=self.cfg.d_state,
+            d_conv=self.cfg.d_conv,
+            expand=self.cfg.expand,
+        )
+
+        self.dropout = nn.Dropout(p=cfg.output_dropout)
+
+        self.head = get_head(cfg=cfg, n_in=cfg.hidden_size, n_out=self.output_size)
+
+    def forward(self, data: Dict[str, torch.Tensor]) -> Dict[str, torch.Tensor]:
+        """Perform a forward pass on the CudaLSTM model.
+
+        Parameters
+        ----------
+        data : Dict[str, torch.Tensor]
+            Dictionary, containing input features as key-value pairs.
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            Model outputs and intermediate states as a dictionary.
+                - `y_hat`: model predictions of shape [batch size, sequence length, number of target variables].
+                - `h_n`: hidden state at the last time step of the sequence of shape [batch size, 1, hidden size].
+                - `c_n`: cell state at the last time step of the sequence of shape [batch size, 1, hidden size].
+        """
+        # possibly pass dynamic and static inputs through embedding layers, then concatenate them
+        x_d = self.embedding_net(data)
+        y_hat = self.mamba(x_d)
+        pred = {'y_hat': y_hat}
+        pred.update(self.head(self.dropout(y_hat)))
+
+        return pred

--- a/neuralhydrology/modelzoo/cudamamba.py
+++ b/neuralhydrology/modelzoo/cudamamba.py
@@ -11,15 +11,15 @@ from neuralhydrology.utils.config import Config
 
 
 class CudaMamba(BaseModel):
-    """LSTM model class, which relies on PyTorch's CUDA LSTM class.
+    """Mamba model class, which relies on https://github.com/state-spaces/mamba/tree/main.
 
-    This class implements the standard LSTM combined with a model head, as specified in the config. Depending on the
+    This class implements the Mamba model combined with a model head, as specified in the config. Depending on the
     embedding settings, static and/or dynamic features may or may not be fed through embedding networks before being
-    concatenated and passed through the LSTM.
+    concatenated and passed through the Mamba layer.
     To control the initial forget gate bias, use the config argument `initial_forget_bias`. Often it is useful to set
     this value to a positive value at the start of the model training, to keep the forget gate closed and to facilitate
     the gradient flow.
-    The `CudaLSTM` class only supports single-timescale predictions. Use `MTSLSTM` to train a model and get
+    The `CudaMamba` class only supports single-timescale predictions. Use `???` to train a model and get
     predictions on multiple temporal resolutions at the same time.
 
     Parameters
@@ -28,7 +28,7 @@ class CudaMamba(BaseModel):
         The run configuration.
     """
     # specify submodules of the model that can later be used for finetuning. Names must match class attributes
-    module_parts = ['embedding_net', 'lstm', 'head']
+    module_parts = ['embedding_net', 'mamba', 'head']
 
     def __init__(self, cfg: Config):
         super(CudaMamba, self).__init__(cfg=cfg)

--- a/neuralhydrology/modelzoo/mamba.py
+++ b/neuralhydrology/modelzoo/mamba.py
@@ -20,10 +20,6 @@ class Mamba(BaseModel):
     layer to ensure the input dimensions match the mamba_ssm specifications. Please read the mamba
     documentation to better learn about required hyperparameters.
 
-    To control the initial forget gate bias, use the config argument `initial_forget_bias`. Often it is useful to set
-    this value to a positive value at the start of the model training, to keep the forget gate closed and to facilitate
-    the gradient flow.
-
     Parameters
     ----------
     cfg : Config

--- a/neuralhydrology/modelzoo/mamba.py
+++ b/neuralhydrology/modelzoo/mamba.py
@@ -4,7 +4,7 @@ try:
     from mamba_ssm import Mamba as Mamba_SSM
 except ModuleNotFoundError:
     raise ModuleNotFoundError(
-        f"mamba_ssm and dependencies required. Please run: pip install mamba_ssm causal-conv1d>=1.1.0"
+        f"mamba_ssm, and dependencies, required. Please run: pip install mamba_ssm causal-conv1d>=1.1.0"
     )
 import torch
 import torch.nn as nn

--- a/neuralhydrology/modelzoo/mamba.py
+++ b/neuralhydrology/modelzoo/mamba.py
@@ -3,9 +3,7 @@ from typing import Dict
 try:
     from mamba_ssm import Mamba as Mamba_SSM
 except ModuleNotFoundError:
-    raise ModuleNotFoundError(
-        f"mamba_ssm, and dependencies, required. Please run: pip install mamba_ssm causal-conv1d>=1.1.0"
-    )
+    Mamba_SSM = None
 import torch
 import torch.nn as nn
 
@@ -42,12 +40,17 @@ class Mamba(BaseModel):
         # using a linear layer to move from the emdedded_layer dims to the specified hidden size
         self.transition_layer = nn.Linear(self.embedding_net.output_size, self.cfg.hidden_size)
 
-        self.mamba = Mamba_SSM(
-            d_model=self.cfg.hidden_size,
-            d_state=self.cfg.mamba_d_state,
-            d_conv=self.cfg.mamba_d_conv,
-            expand=self.cfg.mamba_expand,
-        )
+        if Mamba_SSM is None:
+            raise ModuleNotFoundError(
+                f"mamba_ssm, and dependencies, required. Please run: pip install mamba_ssm causal-conv1d>=1.1.0"
+            )
+        else:
+            self.mamba = Mamba_SSM(
+                d_model=self.cfg.hidden_size,
+                d_state=self.cfg.mamba_d_state,
+                d_conv=self.cfg.mamba_d_conv,
+                expand=self.cfg.mamba_expand,
+            )
 
         self.dropout = nn.Dropout(p=cfg.output_dropout)
 

--- a/neuralhydrology/utils/config.py
+++ b/neuralhydrology/utils/config.py
@@ -313,11 +313,11 @@ class Config(object):
 
     @property
     def d_conv(self) -> dict:
-        return self._as_default_dict(self._cfg.get("d_conv", {}))
+        return self._cfg.get("d_conv", 4)
 
     @property
     def d_state(self) -> dict:
-        return self._as_default_dict(self._cfg.get("d_state", {}))
+        return self._cfg.get("d_state", 16)
 
     @property
     def data_dir(self) -> Path:
@@ -380,7 +380,7 @@ class Config(object):
 
     @property
     def expand(self) -> dict:
-        return self._as_default_dict(self._cfg.get("expand", {}))
+        return self._cfg.get("expand", 2)
 
     @property
     def experiment_name(self) -> str:

--- a/neuralhydrology/utils/config.py
+++ b/neuralhydrology/utils/config.py
@@ -312,14 +312,6 @@ class Config(object):
         return self._as_default_dict(self._cfg.get("custom_normalization", {}))
 
     @property
-    def d_conv(self) -> dict:
-        return self._cfg.get("d_conv", 4)
-
-    @property
-    def d_state(self) -> dict:
-        return self._cfg.get("d_state", 16)
-
-    @property
     def data_dir(self) -> Path:
         return self._get_value_verbose("data_dir")
 
@@ -377,10 +369,6 @@ class Config(object):
             return self._as_default_list(self._cfg["static_inputs"])
         else:
             return []
-
-    @property
-    def expand(self) -> dict:
-        return self._cfg.get("expand", 2)
 
     @property
     def experiment_name(self) -> str:
@@ -530,6 +518,18 @@ class Config(object):
     @loss.setter
     def loss(self, loss: str):
         self._cfg["loss"] = loss
+
+    @property
+    def mamba_d_conv(self) -> int:
+        return self._cfg.get("d_conv", 4)
+
+    @property
+    def mamba_d_state(self) -> int:
+        return self._cfg.get("d_state", 16)
+
+    @property
+    def mamba_expand(self) -> int:
+        return self._cfg.get("expand", 2)
 
     @property
     def mass_inputs(self) -> List[str]:

--- a/neuralhydrology/utils/config.py
+++ b/neuralhydrology/utils/config.py
@@ -312,6 +312,14 @@ class Config(object):
         return self._as_default_dict(self._cfg.get("custom_normalization", {}))
 
     @property
+    def d_conv(self) -> dict:
+        return self._as_default_dict(self._cfg.get("d_conv", {}))
+
+    @property
+    def d_state(self) -> dict:
+        return self._as_default_dict(self._cfg.get("d_state", {}))
+
+    @property
     def data_dir(self) -> Path:
         return self._get_value_verbose("data_dir")
 
@@ -369,6 +377,10 @@ class Config(object):
             return self._as_default_list(self._cfg["static_inputs"])
         else:
             return []
+
+    @property
+    def expand(self) -> dict:
+        return self._as_default_dict(self._cfg.get("expand", {}))
 
     @property
     def experiment_name(self) -> str:


### PR DESCRIPTION
# Added:
- Implemented the [Mamba](https://github.com/state-spaces/mamba/tree/main) SSM within NH
  - NOTE: within Mamba there is a transition `nn.Linear` layer that changes the dimensions from the embedding layer to the hidden size. This is per Mamba's requirements as it expects inputs to be of the model's hidden size (read Mamba's README for more information)
```py
self.transition_layer = nn.Linear(self.embedding_net.output_size, self.cfg.hidden_size)
```
- made changes to the `Config.py` file to set the internal hyperparameters within Mamba
  - added: `d_state`, `d_conv`, and `expand`


# Tests:
- We ran a full 30 epoch validation testing and was able to generate mid performance (~0.4 NSE). Excited to see what experiments people run with this. 

![image](https://github.com/neuralhydrology/neuralhydrology/assets/16233925/79540c31-240b-43f2-b9ab-bcb08d4fcb50)
