### PR TITLE
Replace deprecated pandas.Series.iteritems() with .items()

### DIFF
--- a/neuralhydrology/datautils/utils.py
+++ b/neuralhydrology/datautils/utils.py
@@ -150,7 +150,7 @@ def attributes_sanity_check(df: pd.DataFrame):
     # Check for NaNs in standard deviation of attributes.
     attributes = []
     if any(df.std() == 0.0) or any(df.std().isnull()):
-        for k, v in df.std().iteritems():
+        for k, v in df.std().items():
             if (v == 0) or (np.isnan(v)):
                 attributes.append(k)
     if attributes:
@@ -166,7 +166,7 @@ def attributes_sanity_check(df: pd.DataFrame):
     if len(nan_df) > 0:
         failure_cases = defaultdict(list)
         for basin, row in nan_df.iterrows():
-            for feature, value in row.iteritems():
+            for feature, value in row.items():
                 if np.isnan(value):
                     failure_cases[basin].append(feature)
         # create verbose error message


### PR DESCRIPTION
Pandas deprecated `.iteritems()` on Series objects in v1.5. The environment files do not pin versions, so they will currently install the latest stable version of pandas (v2.1.4) and the training code thus cannot run. 

The suggested replacement is `.items()` https://pandas.pydata.org/pandas-docs/version/1.5/reference/api/pandas.Series.iteritems.html

This has been the only issue I've had with using a newer version of pandas than expected.