### PR TITLE
Bugfix: Caravan v1.3 with outer join on CSV caused NaNs. So I suggest inner join.

### DIFF
--- a/neuralhydrology/datasetzoo/caravan.py
+++ b/neuralhydrology/datasetzoo/caravan.py
@@ -195,4 +195,4 @@ def _load_attribute_files_of_subdataset(subdataset_dir: Path) -> pd.DataFrame:
     dfs = []
     for csv_file in subdataset_dir.glob("*.csv"):
         dfs.append(pd.read_csv(csv_file, index_col="gauge_id"))
-    return pd.concat(dfs, axis=1, join='inner')
+    return pd.concat(dfs, axis=1, join="inner")

--- a/neuralhydrology/datasetzoo/caravan.py
+++ b/neuralhydrology/datasetzoo/caravan.py
@@ -195,4 +195,4 @@ def _load_attribute_files_of_subdataset(subdataset_dir: Path) -> pd.DataFrame:
     dfs = []
     for csv_file in subdataset_dir.glob("*.csv"):
         dfs.append(pd.read_csv(csv_file, index_col="gauge_id"))
-    return pd.concat(dfs, axis=1)
+    return pd.concat(dfs, axis=1, join='inner')


### PR DESCRIPTION
In: https://github.com/kratzert/Caravan/issues/16 it is noted that the the Caravan dataset has had a mismatch in gauge ids between the csvs. I believe it is still there, but the issue is marked as complete; so it probably won't always be there.

In any case, I think NeuralHydrology could handle this more gracefully. Right now, a mismatch in gauge ids causes the nh_run.py script to fail because [`datasetzoo/caravan.py:_load_attribute_files_of_subdataset()`](https://github.com/neuralhydrology/neuralhydrology/blob/master/neuralhydrology/datasetzoo/caravan.py#L193) implicitly does an outer join across the CSV files to create the columns. This creates a dataframe with NaNs even though there weren't any NaNs in the basin attribute CSVs. And this is then picked up by [`datautils/utils.py:attributes_sanity_check`](https://github.com/neuralhydrology/neuralhydrology/blob/master/neuralhydrology/datautils/utils.py#L133) as a failure to read data.

My proposed solution is to make it an explicit inner join, dropping gauges which do not appear in all CSVs. This seems reasonable to me, except maybe that it is silently doing this. Let me know if I should make it log a warning when this is detected, too.

More broadly, I expected it to only complain if the gauges included in the train, val and test split files had any issues. Since we have to provide our own splits, I assumed that this could be a mechanism to skip gauges that had bad data. But, no, that filtering happens later, so you have to instead go in and edit the CSVs, I guess? If that filtering was done before any sanity checking, then you could theoretically add a dataset which had NaNs, but not include them in your splits and it would be fine. I can make such changes if you think that would be beneficial, but I don't need such changes right now, so I didn't. 