### PR TITLE
Add AdamW to optimizers and ReLU to fc activations

### DIFF
--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -350,7 +350,7 @@ Training settings
 -----------------
 
 -  ``optimizer``: Specify which optimizer to use. Currently supported
-   are Adam (default) and AdamW. New optimizers can be added
+   are Adam and AdamW. New optimizers can be added
    :py:func:`here <neuralhydrology.training.get_optimizer>`.
 
 -  ``loss``: Which loss to use. Currently supported are ``MSE``,

--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -334,7 +334,8 @@ the EA-LSTM model. For multi-timescale models, these settings can be ignored.
    - ``type`` (default 'fc'): Type of the embedding net. Currently, only 'fc' for fully-connected net is supported.
    - ``hiddens``: List of integers that define the number of neurons per layer in the fully connected network.
      The last number is the number of output neurons. Must have at least length one.
-   - ``activation`` (default 'tanh'): activation function of the network. Supported values are 'tanh', 'sigmoid', 'linear'.
+   - ``activation`` (default 'tanh'): activation function of the network. Supported values are:
+     'tanh', 'sigmoid', 'linear', and 'relu'.
      The activation function is not applied to the output neurons, which always have a linear activation function.
      An activation function for the output neurons has to be applied in the main model class.
    - ``dropout`` (default 0.0): Dropout rate applied to the embedding network.
@@ -349,7 +350,7 @@ Training settings
 -----------------
 
 -  ``optimizer``: Specify which optimizer to use. Currently supported
-   is Adam (standard). New optimizers can be added
+   are Adam (default) and AdamW. New optimizers can be added
    :py:func:`here <neuralhydrology.training.get_optimizer>`.
 
 -  ``loss``: Which loss to use. Currently supported are ``MSE``,

--- a/neuralhydrology/modelzoo/fc.py
+++ b/neuralhydrology/modelzoo/fc.py
@@ -59,6 +59,8 @@ class FC(nn.Module):
             activation = nn.Tanh()
         elif name.lower() == "sigmoid":
             activation = nn.Sigmoid()
+        elif name.lower() == "relu":
+            activation = nn.ReLU()
         elif name.lower() == "linear":
             activation = nn.Identity()
         else:

--- a/neuralhydrology/training/__init__.py
+++ b/neuralhydrology/training/__init__.py
@@ -30,6 +30,8 @@ def get_optimizer(model: torch.nn.Module, cfg: Config) -> torch.optim.Optimizer:
     """
     if cfg.optimizer.lower() == "adam":
         optimizer = torch.optim.Adam(model.parameters(), lr=cfg.learning_rate[0])
+    elif cfg.optimizer.lower() == "adamw":
+        optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.learning_rate[0])
     else:
         raise NotImplementedError(f"{cfg.optimizer} not implemented or not linked in `get_optimizer()`")
 

--- a/neuralhydrology/training/__init__.py
+++ b/neuralhydrology/training/__init__.py
@@ -14,7 +14,7 @@ LOGGER = logging.getLogger(__name__)
 def get_optimizer(model: torch.nn.Module, cfg: Config) -> torch.optim.Optimizer:
     """Get specific optimizer object, depending on the run configuration.
     
-    Currently only 'Adam' is supported.
+    Currently only 'Adam' and 'AdamW' are supported.
     
     Parameters
     ----------


### PR DESCRIPTION
I think these options should be included in NeuralHydrology, for the reasons noted below:

- optimizers: Add AdamW. AdamW is effectively Adam, but with weight decay fixed (there was an mathematical error in the original formulation). In my experience in other projects, AdamW - with default weight decay - gives a small, but very consistent performance boost compared to Adam.
- modelzoo/fc: Add ReLU. ReLU is the most common activation function for Linear and Conv layers.