### PR TITLE
Continue run from last epoch when config file is specified.

### DIFF
--- a/neuralhydrology/nh_run.py
+++ b/neuralhydrology/nh_run.py
@@ -96,6 +96,7 @@ def continue_run(run_dir: Path, config_file: Path = None, gpu: int = None):
 
     if config_file is not None:
         base_config.update_config(config_file)
+        base_config.run_dir = run_dir
 
     base_config.is_continue_training = True
 


### PR DESCRIPTION
There was a bug where if a config file was supplied to continue_run, it overwrote the run directory so that the BaseTrainer could not find the epoch weight files. The fix is to replace the run_dir in the config file before starting the run.