### PR TITLE
Moved all data scaling functions to a dedicated Scaler object.

### DIFF
--- a/neuralhydrology/datasetzoo/__init__.py
+++ b/neuralhydrology/datasetzoo/__init__.py
@@ -20,7 +20,7 @@ def get_dataset(cfg: Config,
                 basin: str = None,
                 additional_features: list = [],
                 id_to_int: dict = {},
-                scaler: dict = {}) -> BaseDataset:
+                compute_scaler: bool = False) -> BaseDataset:
     """Get data set instance, depending on the run configuration.
 
     Currently implemented datasets are 'caravan', 'camels_aus', 'camels_br', 'camels_cl', 'camels_gb', 'camels_us', and
@@ -50,9 +50,9 @@ def get_dataset(cfg: Config,
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
 
     Returns
     -------
@@ -66,7 +66,7 @@ def get_dataset(cfg: Config,
     """
     global _datasetZooRegistry
 
-    return _datasetZooRegistry.instantiate_dataset(cfg, is_train, period, basin, additional_features, id_to_int, scaler)
+    return _datasetZooRegistry.instantiate_dataset(cfg, is_train, period, basin, additional_features, id_to_int, compute_scaler)
 
 
 def register_dataset(key: str, new_class: Type):

--- a/neuralhydrology/datasetzoo/camelsaus.py
+++ b/neuralhydrology/datasetzoo/camelsaus.py
@@ -1,9 +1,8 @@
 from pathlib import Path
-from typing import List, Dict, Union
+from typing import List, Dict
 
 import numpy as np
 import pandas as pd
-import xarray
 from tqdm import tqdm
 
 from neuralhydrology.datasetzoo.basedataset import BaseDataset
@@ -39,9 +38,9 @@ class CamelsAUS(BaseDataset):
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or 
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
 
     References
     ----------
@@ -57,14 +56,14 @@ class CamelsAUS(BaseDataset):
                  basin: str = None,
                  additional_features: List[Dict[str, pd.DataFrame]] = [],
                  id_to_int: Dict[str, int] = {},
-                 scaler: Dict[str, Union[pd.Series, xarray.DataArray]] = {}):
+                 compute_scaler: bool = True):
         super(CamelsAUS, self).__init__(cfg=cfg,
                                         is_train=is_train,
                                         period=period,
                                         basin=basin,
                                         additional_features=additional_features,
                                         id_to_int=id_to_int,
-                                        scaler=scaler)
+                                        compute_scaler=compute_scaler)
 
     def _load_basin_data(self, basin: str) -> pd.DataFrame:
         """Load input and output data from text files."""

--- a/neuralhydrology/datasetzoo/camelsbr.py
+++ b/neuralhydrology/datasetzoo/camelsbr.py
@@ -1,8 +1,7 @@
 from pathlib import Path
-from typing import List, Dict, Union
+from typing import List, Dict
 
 import pandas as pd
-import xarray
 from tqdm import tqdm
 
 from neuralhydrology.datasetzoo.basedataset import BaseDataset
@@ -51,9 +50,9 @@ class CamelsBR(BaseDataset):
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or 
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
 
     References
     ----------
@@ -69,14 +68,14 @@ class CamelsBR(BaseDataset):
                  basin: str = None,
                  additional_features: List[Dict[str, pd.DataFrame]] = [],
                  id_to_int: Dict[str, int] = {},
-                 scaler: Dict[str, Union[pd.Series, xarray.DataArray]] = {}):
+                 compute_scaler: bool = True):
         super(CamelsBR, self).__init__(cfg=cfg,
                                        is_train=is_train,
                                        period=period,
                                        basin=basin,
                                        additional_features=additional_features,
                                        id_to_int=id_to_int,
-                                       scaler=scaler)
+                                       compute_scaler=compute_scaler)
 
     def _load_basin_data(self, basin: str) -> pd.DataFrame:
         """Load input and output data from text files."""

--- a/neuralhydrology/datasetzoo/camelscl.py
+++ b/neuralhydrology/datasetzoo/camelscl.py
@@ -1,10 +1,9 @@
 import sys
 from pathlib import Path
-from typing import List, Dict, Union
+from typing import List, Dict
 
 import numpy as np
 import pandas as pd
-import xarray
 from tqdm import tqdm
 
 from neuralhydrology.datasetzoo.basedataset import BaseDataset
@@ -40,9 +39,9 @@ class CamelsCL(BaseDataset):
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or 
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
 
     References
     ----------
@@ -59,14 +58,14 @@ class CamelsCL(BaseDataset):
                  basin: str = None,
                  additional_features: List[Dict[str, pd.DataFrame]] = [],
                  id_to_int: Dict[str, int] = {},
-                 scaler: Dict[str, Union[pd.Series, xarray.DataArray]] = {}):
+                 compute_scaler: bool = True):
         super(CamelsCL, self).__init__(cfg=cfg,
                                        is_train=is_train,
                                        period=period,
                                        basin=basin,
                                        additional_features=additional_features,
                                        id_to_int=id_to_int,
-                                       scaler=scaler)
+                                       compute_scaler=compute_scaler)
 
     def _load_basin_data(self, basin: str) -> pd.DataFrame:
         """Load input and output data from text files."""

--- a/neuralhydrology/datasetzoo/camelsgb.py
+++ b/neuralhydrology/datasetzoo/camelsgb.py
@@ -1,8 +1,7 @@
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List
 
 import pandas as pd
-import xarray
 
 from neuralhydrology.datasetzoo.basedataset import BaseDataset
 from neuralhydrology.utils.config import Config
@@ -32,9 +31,9 @@ class CamelsGB(BaseDataset):
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or 
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
         
     References
     ----------
@@ -51,14 +50,14 @@ class CamelsGB(BaseDataset):
                  basin: str = None,
                  additional_features: List[Dict[str, pd.DataFrame]] = [],
                  id_to_int: Dict[str, int] = {},
-                 scaler: Dict[str, Union[pd.Series, xarray.DataArray]] = {}):
+                 compute_scaler: bool = True):
         super(CamelsGB, self).__init__(cfg=cfg,
                                        is_train=is_train,
                                        period=period,
                                        basin=basin,
                                        additional_features=additional_features,
                                        id_to_int=id_to_int,
-                                       scaler=scaler)
+                                       compute_scaler=compute_scaler)
 
     def _load_basin_data(self, basin: str) -> pd.DataFrame:
         """Load input and output data from text files."""

--- a/neuralhydrology/datasetzoo/camelsus.py
+++ b/neuralhydrology/datasetzoo/camelsus.py
@@ -1,9 +1,8 @@
 from pathlib import Path
-from typing import Dict, List, Tuple, Union
+from typing import Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
-import xarray
 
 from neuralhydrology.datasetzoo.basedataset import BaseDataset
 from neuralhydrology.utils.config import Config
@@ -33,9 +32,9 @@ class CamelsUS(BaseDataset):
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or 
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
         
     References
     ----------
@@ -56,14 +55,14 @@ class CamelsUS(BaseDataset):
                  basin: str = None,
                  additional_features: List[Dict[str, pd.DataFrame]] = [],
                  id_to_int: Dict[str, int] = {},
-                 scaler: Dict[str, Union[pd.Series, xarray.DataArray]] = {}):
+                 compute_scaler: bool = True):
         super(CamelsUS, self).__init__(cfg=cfg,
                                        is_train=is_train,
                                        period=period,
                                        basin=basin,
                                        additional_features=additional_features,
                                        id_to_int=id_to_int,
-                                       scaler=scaler)
+                                       compute_scaler=compute_scaler)
 
     def _load_basin_data(self, basin: str) -> pd.DataFrame:
         """Load input and output data from text files."""

--- a/neuralhydrology/datasetzoo/caravan.py
+++ b/neuralhydrology/datasetzoo/caravan.py
@@ -32,9 +32,9 @@ class Caravan(BaseDataset):
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or 
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
 
     References
     ----------
@@ -51,7 +51,7 @@ class Caravan(BaseDataset):
                  basin: str = None,
                  additional_features: List[Dict[str, pd.DataFrame]] = [],
                  id_to_int: Dict[str, int] = {},
-                 scaler: Dict[str, Union[pd.Series, xarray.DataArray]] = {}):
+                 compute_scaler: bool = True):
         # initialize parent class
         super(Caravan, self).__init__(cfg=cfg,
                                       is_train=is_train,
@@ -59,7 +59,7 @@ class Caravan(BaseDataset):
                                       basin=basin,
                                       additional_features=additional_features,
                                       id_to_int=id_to_int,
-                                      scaler=scaler)
+                                      compute_scaler=compute_scaler)
 
     def _load_basin_data(self, basin: str) -> pd.DataFrame:
         """Load timeseries data from netcdf files."""

--- a/neuralhydrology/datasetzoo/datasetregistry.py
+++ b/neuralhydrology/datasetzoo/datasetregistry.py
@@ -46,7 +46,7 @@ class DatasetRegistry:
                             basin: str = None,
                             additional_features: list = [],
                             id_to_int: dict = {},
-                            scaler: dict = {}) -> BaseDataset:
+                            compute_scaler: bool = True) -> BaseDataset:
         """Creates and returns an instance of a dataset class based on the configuration.
 
         Parameters
@@ -70,9 +70,9 @@ class DatasetRegistry:
         id_to_int : Dict[str, int], optional
             If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or
             'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-        scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-            If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-            for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+        compute_scaler : bool
+            Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+            not finetuning.
 
         Returns
         -------
@@ -95,4 +95,4 @@ class DatasetRegistry:
                        basin=basin,
                        additional_features=additional_features,
                        id_to_int=id_to_int,
-                       scaler=scaler)
+                       compute_scaler=compute_scaler)

--- a/neuralhydrology/datasetzoo/genericdataset.py
+++ b/neuralhydrology/datasetzoo/genericdataset.py
@@ -1,6 +1,6 @@
 from functools import reduce
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List
 
 import numpy as np
 import pandas as pd
@@ -45,9 +45,10 @@ class GenericDataset(BaseDataset):
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
+
     """
 
     def __init__(self,
@@ -57,14 +58,14 @@ class GenericDataset(BaseDataset):
                  basin: str = None,
                  additional_features: List[Dict[str, pd.DataFrame]] = [],
                  id_to_int: Dict[str, int] = {},
-                 scaler: Dict[str, Union[pd.Series, xarray.DataArray]] = {}):
+                 compute_scaler: bool = True):
         super(GenericDataset, self).__init__(cfg=cfg,
                                              is_train=is_train,
                                              period=period,
                                              basin=basin,
                                              additional_features=additional_features,
                                              id_to_int=id_to_int,
-                                             scaler=scaler)
+                                             compute_scaler=compute_scaler)
 
     def _load_basin_data(self, basin: str) -> pd.DataFrame:
         """Load input and output data. """

--- a/neuralhydrology/datasetzoo/hourlycamelsus.py
+++ b/neuralhydrology/datasetzoo/hourlycamelsus.py
@@ -39,9 +39,10 @@ class HourlyCamelsUS(camelsus.CamelsUS):
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
+
     """
 
     def __init__(self,
@@ -51,7 +52,7 @@ class HourlyCamelsUS(camelsus.CamelsUS):
                  basin: str = None,
                  additional_features: list = [],
                  id_to_int: dict = {},
-                 scaler: dict = {}):
+                 compute_scaler: bool = True):
         self._netcdf_datasets = {}  # if available, we remember the dataset to load faster
         self._warn_slow_loading = True
         super(HourlyCamelsUS, self).__init__(cfg=cfg,
@@ -60,7 +61,7 @@ class HourlyCamelsUS(camelsus.CamelsUS):
                                              basin=basin,
                                              additional_features=additional_features,
                                              id_to_int=id_to_int,
-                                             scaler=scaler)
+                                             compute_scaler=compute_scaler)
 
     def _load_basin_data(self, basin: str) -> pd.DataFrame:
         """Load input and output data from text files."""

--- a/neuralhydrology/datasetzoo/lamah.py
+++ b/neuralhydrology/datasetzoo/lamah.py
@@ -1,9 +1,8 @@
 from pathlib import Path
-from typing import List, Dict, Union
+from typing import List, Dict
 
 import numpy as np
 import pandas as pd
-import xarray
 
 from neuralhydrology.datasetzoo.basedataset import BaseDataset
 from neuralhydrology.datautils import utils
@@ -52,9 +51,9 @@ class LamaH(BaseDataset):
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or 
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
 
     References
     ----------
@@ -70,7 +69,7 @@ class LamaH(BaseDataset):
                  basin: str = None,
                  additional_features: List[Dict[str, pd.DataFrame]] = [],
                  id_to_int: Dict[str, int] = {},
-                 scaler: Dict[str, Union[pd.Series, xarray.DataArray]] = {}):
+                 compute_scaler: bool = True):
         # Discharge is provided in m3/s in the data set as 'Qobs [m3/s]'. We allow to use 'Qobs [mm/h]' or 'Qobs [mm/d]'
         # in the config and in this case will normalize on the fly. For that, we need the basin area
         self._all_variables = self._get_list_of_all_variables(cfg)
@@ -85,7 +84,7 @@ class LamaH(BaseDataset):
                                     basin=basin,
                                     additional_features=additional_features,
                                     id_to_int=id_to_int,
-                                    scaler=scaler)
+                                    compute_scaler=compute_scaler)
 
     @staticmethod
     def _get_list_of_all_variables(cfg: Config) -> List[str]:

--- a/neuralhydrology/datasetzoo/template.py
+++ b/neuralhydrology/datasetzoo/template.py
@@ -1,7 +1,6 @@
-from typing import List, Dict, Union
+from typing import List, Dict
 
 import pandas as pd
-import xarray
 
 from neuralhydrology.datasetzoo.basedataset import BaseDataset
 from neuralhydrology.utils.config import Config
@@ -43,9 +42,9 @@ class TemplateDataset(BaseDataset):
     id_to_int : Dict[str, int], optional
         If the config argument 'use_basin_id_encoding' is True in the config and period is either 'validation' or 
         'test', this input is required. It is a dictionary, mapping from basin id to an integer (the one-hot encoding).
-    scaler : Dict[str, Union[pd.Series, xarray.DataArray]], optional
-        If period is either 'validation' or 'test', this input is required. It contains the centering and scaling
-        for each feature and is stored to the run directory during training (train_data/train_data_scaler.yml).
+    compute_scaler : bool
+        Forces the dataset to calculate a new scaler instead of loading a precalculated scaler. Used during training, but
+        not finetuning.
 
     """
 
@@ -56,7 +55,7 @@ class TemplateDataset(BaseDataset):
                  basin: str = None,
                  additional_features: List[Dict[str, pd.DataFrame]] = [],
                  id_to_int: Dict[str, int] = {},
-                 scaler: Dict[str, Union[pd.Series, xarray.DataArray]] = {}):
+                 compute_scaler: bool = True):
         # initialize parent class
         super(TemplateDataset, self).__init__(cfg=cfg,
                                               is_train=is_train,
@@ -64,7 +63,7 @@ class TemplateDataset(BaseDataset):
                                               basin=basin,
                                               additional_features=additional_features,
                                               id_to_int=id_to_int,
-                                              scaler=scaler)
+                                              compute_scaler=compute_scaler)
 
     def _load_basin_data(self, basin: str) -> pd.DataFrame:
         """Load basin time series data

--- a/neuralhydrology/datautils/scaler.py
+++ b/neuralhydrology/datautils/scaler.py
@@ -1,0 +1,221 @@
+import os
+from pathlib import Path
+from typing import Dict, Optional
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from neuralhydrology.datautils.utils import load_scaler as old_load_scaler
+
+SCALER_FILE_NAME = 'scaler.nc'
+
+
+def _get_center(feature_da: xr.DataArray, centering_type: str) -> float:
+    """Canonical selector for currently-supported center types."""
+    if (centering_type is None) or (centering_type.lower() == 'none'):
+        return np.float32(0.0)
+    elif centering_type.lower() == 'median':
+        return feature_da.median(skipna=True)
+    elif centering_type.lower() == 'min':
+        return feature_da.min(skipna=True)
+    elif centering_type.lower() == 'mean':
+        return feature_da.mean(skipna=True)
+    else:
+        raise ValueError(f'Unknown centering method {centering_type}')
+
+        
+def _get_scale(feature_da: xr.DataArray, scaling_type: str) -> float:
+    """Canonical selector for currently-supported scale types."""
+    if (scaling_type is None) or (scaling_type.lower() == 'none'):
+        return np.float32(1.0)
+    elif scaling_type.lower() == 'minmax':
+        return feature_da.max(skipna=True) - feature_da.min(skipna=True)
+    elif scaling_type.lower() == 'std':
+        return feature_da.std(skipna=True)
+    else:
+        raise ValueError(f'Unknown scaling method {scaling_type}')
+
+
+class Scaler():
+    """Scaler for a dataset that contains multiple features.
+    
+    Parameters
+    ----------
+    scaler_dir : pathlib.Path
+        Directory for loading a pre-calculated scaler or saving this scaler if it is calculated.
+    calculate_scaler : bool
+        Flag to indicate if the scaler should be computed (the alternative is to load an existing scaler file).
+    custom_normalization : Dict[str, Dict[str, float]]
+        Feature-specific scaling instructions as a mapping from feature name to centering and/or scaling type.
+        See docs for a list of accepted types and their meaning.
+    dataset : Optional[xr.Dataset]
+        Dataset to use for calculating a new scaler. Cannot be supplied if `calculate_scaler` is False.
+        
+    Raises
+    -------
+    ValueError for incompatible loading/calculating instructions.
+    """
+    
+    def __init__(
+        self,
+        scaler_dir: Path,
+        calculate_scaler,
+        custom_normalization: Dict[str, Dict[str, float]] = {},
+        dataset: Optional[xr.Dataset] = None,
+    ):
+        # Consistency check.
+        if not calculate_scaler and dataset is not None:
+            raise ValueError('Do not pass a dataset if you are loading a pre-calculated scaler.')
+
+        # Load or calculate scaling parameters.
+        self.scaler = None
+        self.scaler_dir = scaler_dir
+        if not calculate_scaler:
+            self.load()
+        else:
+            self._custom_normalization = custom_normalization
+            if dataset is not None:
+                self.calculate(dataset)
+   
+    def load(self):
+        scaler_file = self.scaler_dir / SCALER_FILE_NAME
+        if os.path.exists(scaler_file):
+            with open(scaler_file, 'rb') as f:
+                self.scaler = xr.load_dataset(f)
+            self._check_zero_scale()
+            return
+        else:
+            scaler = old_load_scaler(self.scaler_dir)
+            # Add target scalers for tester. Necessary for fine tuning.
+            obs_scaler = scaler.copy().rename({feature: feature + '_obs' for feature in scaler.data_vars})
+            sim_scaler = scaler.copy().rename({feature: feature + '_sim' for feature in scaler.data_vars})
+            self.scaler = xr.merge([scaler, obs_scaler, sim_scaler])
+            self._check_zero_scale()
+            return
+
+    def save(self):
+        if self.scaler is None:
+            raise ValueError('You are trying to save a scaler that has not been computed.')
+        os.makedirs(self.scaler_dir, exist_ok=True)
+        scaler_file = self.scaler_dir / SCALER_FILE_NAME
+        with open(scaler_file, 'wb') as f:
+            self.scaler.to_netcdf(f)
+        
+    def calculate(
+        self,
+        dataset: xr.Dataset,
+    ):
+        
+        # Option for custom scaling for each feature.
+        centering_types = {feature: 'mean' for feature in dataset.data_vars}
+        scaling_types = {feature: 'std' for feature in dataset.data_vars}
+        for feature in self._custom_normalization:
+            if 'centering' in self._custom_normalization[feature]:
+                centering_types[feature] = self._custom_normalization[feature]['centering']
+            if 'scaling' in self._custom_normalization[feature]:
+                scaling_types[feature] = self._custom_normalization[feature]['scaling']
+
+        # Target noise distrbutions (in BaseTrainer) require means and standard deviations.
+        # Force these parameters to be avaiable, even if the targets use a different center
+        # and scale type. Could restrict these extra calculations to only when necessary 
+        # (i.e., targets only, and only when using other scaling types), but this adds
+        # complication and these extra mean and std calcs & storage are cheap.
+        parameters = {
+            feature: (('parameter',), [
+                _get_center(dataset[feature], centering_types[feature]),
+                _get_scale(dataset[feature], scaling_types[feature]),
+                _get_center(dataset[feature], 'mean'),
+                _get_scale(dataset[feature], 'std')
+            ]) for feature in dataset.data_vars
+        }
+        
+        # Expand the scaler dataset to include 'obs' and 'sim' versions of all variables.
+        # As above, this is only necessary for target variables, but a check here adds
+        # complexity for little benefit.
+        parameters.update({f'{feature}_obs': parameters[feature] for feature in parameters})
+        parameters.update({f'{feature}_sim': parameters[feature] for feature in parameters})      
+        
+        # Put the calculated parameters into an xarray dataset.
+        coords = {'parameter': ['center', 'scale', 'mean', 'std']}
+        scaler = xr.Dataset(parameters, coords=coords).astype('float32')
+
+        # Handle cases where part of the scaler is already calculated. Simply add new features.
+        if self.scaler is not None:
+            self.scaler = xr.merge([self.scaler, scaler])
+        else:
+            self.scaler = scaler
+
+        # Ensure that there are no zero-valued scale parameters, as this will cause NaN's.
+        self._check_zero_scale()
+
+    def _check_zero_scale(self):
+        """Raises an error if the scale is zero for any feature."""
+        zero_scale_features = [
+            feature for feature, da in self.scaler.sel(parameter=['scale', 'std']).data_vars.items()
+            if (da == 0).any()
+        ]
+        if any(zero_scale_features):
+             raise ValueError(f'Zero scale values found for features: {zero_scale_features}.')
+        
+    def scale(
+        self,
+        dataset: xr.Dataset,
+    ) -> xr.Dataset:
+        """Scale a data set with a precaculated_scaler.
+        
+        $$ unscaled_dataset = (dataset - center) + scale $$
+
+        Applies a linear transformation to the features (data_vars) in an xr.Dataset.
+        This transformation is the inverse of the one applied by self.unscale().
+        Agnostic to the dimensions and coordinates of the dataset.
+        
+        Parameters
+        ----------
+        dataset : xr.Dataset
+            Dataset to be scaled.
+        
+        Returns
+        -------
+        xr.Dataset
+            The new dataset where all scalable features are scaled.
+        
+        Raises
+        ------
+        ValueError if the dataset contains features that are not in the scaler parameters.
+        """
+        missing_features = [feature for feature in dataset if feature not in self.scaler.data_vars]
+        if any(missing_features):
+            raise ValueError(f'Requesting to scale variables that are not part of the scaler: {missing_features}')
+        return (dataset - self.scaler.sel(parameter='center')) / self.scaler.sel(parameter='scale')
+
+    def unscale(
+        self,
+        dataset: xr.Dataset
+    ) -> xr.Dataset:
+        """Un-scale a data set with a precalculated scaler.
+        
+        $$ scaled_dataset = dataset * scale + center $$
+        
+        Applies a linear transformation to the features (data_vars) in an xr.Dataset.
+        This transformation is the inverse of the one applied by self.scale().
+        Agnostic to the dimensions and coordinates of the dataset.
+        
+        Parameters
+        ----------
+        dataset : xr.Dataset
+            Dataset to be un-scaled.
+        
+        Returns
+        -------
+        xr.Dataset
+            The new dataset where all scalable features are un-scaled. 
+        
+        Raises
+        ------
+        ValueError if the dataset contains features that are not in the scaler parameters.
+        """
+        missing_features = [feature for feature in dataset if feature not in self.scaler.data_vars]
+        if any(missing_features):
+            raise ValueError(f'Requesting to unscale variables that are not part of the scaler: {missing_features}')
+        return dataset * self.scaler.sel(parameter='scale') + self.scaler.sel(parameter='center')

--- a/neuralhydrology/modelzoo/basemodel.py
+++ b/neuralhydrology/modelzoo/basemodel.py
@@ -3,7 +3,7 @@ from typing import Dict
 import torch
 import torch.nn as nn
 
-from neuralhydrology.datautils.utils import load_scaler
+from neuralhydrology.datautils.scaler import Scaler
 from neuralhydrology.utils.config import Config
 from neuralhydrology.utils.samplingutils import sample_pointpredictions, umal_extend_batch
 
@@ -54,7 +54,8 @@ class BaseModel(nn.Module):
         Dict[str, torch.Tensor]
             Sampled point predictions 
         """
-        scaler = load_scaler(self.cfg.run_dir)
+        scaler = Scaler(scaler_dir=self.cfg.run_dir, calculate_scaler=False)
+        scaler.load()
         return sample_pointpredictions(self, data, n_samples, scaler)
 
     def forward(self, data: dict[str, torch.Tensor | dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:

--- a/neuralhydrology/training/regularization.py
+++ b/neuralhydrology/training/regularization.py
@@ -1,6 +1,5 @@
 from typing import Dict
 
-import pandas as pd
 import torch
 
 from neuralhydrology.datautils.utils import get_frequency_factor, sort_frequencies

--- a/test/test_scaler.py
+++ b/test/test_scaler.py
@@ -1,0 +1,301 @@
+"""Unit tests for Scaler."""
+import os
+from pathlib import Path
+from unittest.mock import patch, mock_open
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from neuralhydrology.datautils import utils
+from neuralhydrology.datautils.scaler import Scaler, SCALER_FILE_NAME, _get_center, _get_scale
+
+# Set a fixed seed for reproducible tests
+np.random.seed(42)
+
+# --- Fixtures for Test Data and Scaler Instances ---
+
+@pytest.fixture
+def sample_dataset_basic():
+    """Provides a basic dataset for calculation and scaling."""
+    data = {
+        'temp': (('date', 'basin'), np.array([[10.0, 20.0], [15.0, 25.0], [12.0, 22.0]])),
+        'pressure': (('date', 'basin'), np.array([[1000.0, 1010.0], [1005.0, 1015.0], [1002.0, 1012.0]])),
+    }
+    coords = {
+        'date': pd.to_datetime(['2023-01-01', '2023-01-02', '2023-01-03']),
+        'basin': ['BASIN_1', 'BASIN_2'],
+    }
+    return xr.Dataset(data, coords=coords)
+
+@pytest.fixture
+def sample_dataset_with_constant_var():
+    """Dataset with a constant variable for testing zero scale."""
+    data = {
+        'constant_val': (('x', 'y'), np.array([[5.0, 5.0], [5.0, 5.0]])),
+        'varying_val': (('x', 'y'), np.array([[1.0, 2.0], [3.0, 4.0]])),
+    }
+    coords = {
+        'date': pd.to_datetime(['2023-01-01', '2023-01-02']),
+        'basin': ['BASIN_1', 'BASIN_2'],
+    }
+    return xr.Dataset(data, coords=coords)
+
+@pytest.fixture
+def tmp_scaler_dir(tmp_path):
+    """Provides a temporary directory for scaler file operations."""
+    return tmp_path / "scaler_data"
+
+@pytest.fixture
+def scaler_instance_calculated(tmp_scaler_dir, sample_dataset_basic):
+    """Provides a Scaler instance with calculated stats (no zero scales)."""
+    scaler = Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=sample_dataset_basic)
+    return scaler
+
+# --- Test Helper Functions (_get_center, _get_scale) ---
+
+def test_get_center_none():
+    da = xr.DataArray(np.array([1, 2, 3]))
+    assert _get_center(da, 'none') == 0.0
+
+def test_get_center_mean():
+    da = xr.DataArray(np.array([1, 2, 3]))
+    np.testing.assert_allclose(_get_center(da, 'mean'), 2.0)
+
+def test_get_center_median():
+    da = xr.DataArray(np.array([1, 5, 2]))
+    np.testing.assert_allclose(_get_center(da, 'median'), 2.0)
+
+def test_get_center_min():
+    da = xr.DataArray(np.array([1, 5, 2]))
+    np.testing.assert_allclose(_get_center(da, 'min'), 1.0)
+
+def test_get_center_unknown_type():
+    da = xr.DataArray(np.array([1, 2, 3]))
+    with pytest.raises(ValueError, match="Unknown centering method"):
+        _get_center(da, 'invalid_type')
+
+def test_get_scale_none():
+    da = xr.DataArray(np.array([1, 2, 3]))
+    assert _get_scale(da, 'none') == 1.0
+
+def test_get_scale_std():
+    da = xr.DataArray(np.array([1, 2, 3]))
+    np.testing.assert_allclose(_get_scale(da, 'std'), np.std([1, 2, 3]))
+
+def test_get_scale_minmax():
+    da = xr.DataArray(np.array([1, 5, 2]))
+    np.testing.assert_allclose(_get_scale(da, 'minmax'), 4.0)
+
+def test_get_scale_unknown_type():
+    da = xr.DataArray(np.array([1, 2, 3]))
+    with pytest.raises(ValueError, match="Unknown scaling method"):
+        _get_scale(da, 'invalid_type')
+
+# --- Test Scaler.__init__ ---
+
+def test_scaler_init_calculate_with_dataset(tmp_scaler_dir, sample_dataset_basic):
+    scaler = Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=sample_dataset_basic)
+    assert scaler.scaler is not None
+    assert isinstance(scaler.scaler, xr.Dataset)
+    assert 'temp' in scaler.scaler.data_vars
+    assert 'temp_obs' in scaler.scaler.data_vars
+    assert 'temp_sim' in scaler.scaler.data_vars
+    assert 'parameter' in scaler.scaler.coords
+    assert set(scaler.scaler.coords['parameter'].values) == {'center', 'scale', 'mean', 'std'}
+
+def test_scaler_init_calculate_no_dataset(tmp_scaler_dir):
+    scaler = Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=None)
+    assert scaler.scaler is None
+
+def test_scaler_init_load_with_dataset_raises_error(tmp_scaler_dir, sample_dataset_basic):
+    with pytest.raises(ValueError, match="Do not pass a dataset if you are loading a pre-calculated scaler."):
+        Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=False, dataset=sample_dataset_basic)
+
+# --- Test Scaler.calculate ---
+
+def test_scaler_calculate_parameters_correctness(tmp_scaler_dir, sample_dataset_basic):
+    scaler = Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=None)
+    scaler.calculate(sample_dataset_basic)
+
+    # Verify 'mean' and 'std' parameters
+    expected_mean_temp = sample_dataset_basic['temp'].mean().item()
+    expected_std_temp = sample_dataset_basic['temp'].std().item()
+    expected_mean_pressure = sample_dataset_basic['pressure'].mean().item()
+    expected_std_pressure = sample_dataset_basic['pressure'].std().item()
+
+    np.testing.assert_allclose(scaler.scaler['temp'].sel(parameter='mean').item(), expected_mean_temp, rtol=1e-5)
+    np.testing.assert_allclose(scaler.scaler['temp'].sel(parameter='std').item(), expected_std_temp, rtol=1e-5)
+    np.testing.assert_allclose(scaler.scaler['pressure'].sel(parameter='mean').item(), expected_mean_pressure, rtol=1e-5)
+    np.testing.assert_allclose(scaler.scaler['pressure'].sel(parameter='std').item(), expected_std_pressure, rtol=1e-5)
+
+    # Verify 'center' and 'scale' are also 'mean' and 'std' by default
+    np.testing.assert_allclose(scaler.scaler['temp'].sel(parameter='center').item(), expected_mean_temp, rtol=1e-5)
+    np.testing.assert_allclose(scaler.scaler['temp'].sel(parameter='scale').item(), expected_std_temp, rtol=1e-5)
+
+    # Verify _obs and _sim suffixes are present and refer to the same data
+    assert 'temp_obs' in scaler.scaler.data_vars
+    assert 'temp_sim' in scaler.scaler.data_vars
+    np.testing.assert_allclose(scaler.scaler['temp_obs'].values, scaler.scaler['temp'].values)
+    np.testing.assert_allclose(scaler.scaler['temp_sim'].values, scaler.scaler['temp'].values)
+
+def test_scaler_calculate_custom_normalization(tmp_scaler_dir, sample_dataset_basic):
+    custom_norm = {
+        'temp': {'centering': 'min', 'scaling': 'minmax'},
+        'pressure': {'centering': 'median', 'scaling': 'none'}
+    }
+    scaler = Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=None, custom_normalization=custom_norm)
+    scaler.calculate(sample_dataset_basic)
+
+    # Verify custom 'center' and 'scale'
+    expected_center_temp = sample_dataset_basic['temp'].min().item()
+    expected_scale_temp = (sample_dataset_basic['temp'].max() - sample_dataset_basic['temp'].min()).item()
+    expected_center_pressure = sample_dataset_basic['pressure'].median().item()
+    expected_scale_pressure = 1.0 # 'none' scaling
+
+    np.testing.assert_allclose(scaler.scaler['temp'].sel(parameter='center').item(), expected_center_temp, rtol=1e-5)
+    np.testing.assert_allclose(scaler.scaler['temp'].sel(parameter='scale').item(), expected_scale_temp, rtol=1e-5)
+    np.testing.assert_allclose(scaler.scaler['pressure'].sel(parameter='center').item(), expected_center_pressure, rtol=1e-5)
+    np.testing.assert_allclose(scaler.scaler['pressure'].sel(parameter='scale').item(), expected_scale_pressure, rtol=1e-5)
+
+    # Verify 'mean' and 'std' are always available
+    np.testing.assert_allclose(scaler.scaler['temp'].sel(parameter='mean').item(), sample_dataset_basic['temp'].mean().item(), rtol=1e-5)
+    np.testing.assert_allclose(scaler.scaler['pressure'].sel(parameter='std').item(), sample_dataset_basic['pressure'].std().item(), rtol=1e-5)
+
+# --- MODIFIED TEST for `_check_zero_scale` being called by `calculate` ---
+def test_scaler_calculate_raises_error_for_zero_scale(tmp_scaler_dir, sample_dataset_with_constant_var):
+    # `constant_val` has a standard deviation of 0.0.
+    # The calculate method should now raise a ValueError due to _check_zero_scale().
+    scaler = Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=None)
+    with pytest.raises(ValueError, match="Zero scale values found for features:"):
+        scaler.calculate(sample_dataset_with_constant_var)
+
+# --- NEW TEST: Direct test of _check_zero_scale ---
+def test_check_zero_scale_method_raises_error(tmp_scaler_dir):
+    scaler = Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=None)
+    # Manually set a scaler with a zero value for 'scale'
+    scaler.scaler = xr.Dataset(
+        {
+            'feature_a': (('parameter',), np.array([0.0, 0.0, 1.0, 1.0])), # scale is 0
+            'feature_b': (('parameter',), np.array([0.0, 5.0, 1.0, 1.0]))
+        },
+        coords={'parameter': ['center', 'scale', 'mean', 'std']}
+    )
+    with pytest.raises(ValueError, match="Zero scale values found for features:"):
+        scaler._check_zero_scale()
+
+def test_check_zero_scale_method_no_error_for_nonzero(tmp_scaler_dir):
+    scaler = Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=None)
+    # Manually set a scaler with non-zero values for 'scale' and 'std'
+    scaler.scaler = xr.Dataset(
+        {
+            'feature_a': (('parameter',), np.array([0.0, 1.0, 1.0, 1.0])),
+            'feature_b': (('parameter',), np.array([0.0, 5.0, 1.0, 2.0]))
+        },
+        coords={'parameter': ['center', 'scale', 'mean', 'std']}
+    )
+    # Should not raise an error
+    try:
+        scaler._check_zero_scale()
+    except ValueError:
+        pytest.fail("`_check_zero_scale` raised ValueError unexpectedly for non-zero scale values.")
+
+# --- Test Scaler.scale ---
+
+def test_scaler_scale_basic_functionality(scaler_instance_calculated, sample_dataset_basic):
+    scaled_ds = scaler_instance_calculated.scale(sample_dataset_basic)
+
+    assert isinstance(scaled_ds, xr.Dataset)
+    assert list(scaled_ds.dims.keys()) == list(sample_dataset_basic.dims.keys())
+    assert set(scaled_ds.data_vars.keys()) == set(sample_dataset_basic.data_vars.keys())
+
+    # Verify mean is approx 0 and std is approx 1 for scaled data
+    # Note: This holds true when scaling the dataset used for calculation
+    np.testing.assert_allclose(scaled_ds['temp'].mean().item(), 0.0, atol=1e-5)
+    np.testing.assert_allclose(scaled_ds['temp'].std().item(), 1.0, rtol=1e-5)
+    np.testing.assert_allclose(scaled_ds['pressure'].mean().item(), 0.0, atol=1e-5)
+    np.testing.assert_allclose(scaled_ds['pressure'].std().item(), 1.0, rtol=1e-5)
+
+
+def test_scaler_scale_new_dataset(scaler_instance_calculated, sample_dataset_basic):
+    new_ds = sample_dataset_basic * 2.0
+    scaled_ds = scaler_instance_calculated.scale(new_ds)
+
+    expected_scaled_temp = (new_ds['temp'] - scaler_instance_calculated.scaler['temp'].sel(parameter='center')) / scaler_instance_calculated.scaler['temp'].sel(parameter='scale')
+    expected_scaled_pressure = (new_ds['pressure'] - scaler_instance_calculated.scaler['pressure'].sel(parameter='center')) / scaler_instance_calculated.scaler['pressure'].sel(parameter='scale')
+
+    np.testing.assert_allclose(scaled_ds['temp'].values, expected_scaled_temp.values, rtol=1e-5)
+    np.testing.assert_allclose(scaled_ds['pressure'].values, expected_scaled_pressure.values, rtol=1e-5)
+
+def test_scaler_scale_raises_error_for_missing_features(scaler_instance_calculated):
+    ds_with_extra = xr.Dataset({'extra_var': (('x',), [1, 2])})
+    with pytest.raises(ValueError, match="Requesting to scale variables that are not part of the scaler:"):
+        scaler_instance_calculated.scale(ds_with_extra)
+
+# --- Test Scaler.unscale ---
+
+def test_scaler_unscale_basic_functionality(scaler_instance_calculated, sample_dataset_basic):
+    scaled_ds = scaler_instance_calculated.scale(sample_dataset_basic)
+    unscaled_ds = scaler_instance_calculated.unscale(scaled_ds)
+
+    assert isinstance(unscaled_ds, xr.Dataset)
+    assert list(unscaled_ds.dims.keys()) == list(sample_dataset_basic.dims.keys())
+    assert set(unscaled_ds.data_vars.keys()) == set(sample_dataset_basic.data_vars.keys())
+
+    # Assert that unscaled data is very close to the original
+    np.testing.assert_allclose(unscaled_ds['temp'].values, sample_dataset_basic['temp'].values, rtol=1e-5)
+    np.testing.assert_allclose(unscaled_ds['pressure'].values, sample_dataset_basic['pressure'].values, rtol=1e-5)
+
+def test_scaler_unscale_new_dataset(scaler_instance_calculated, sample_dataset_basic):
+    new_ds = sample_dataset_basic * 2.0
+    scaled_ds = scaler_instance_calculated.scale(new_ds)
+    unscaled_ds = scaler_instance_calculated.unscale(scaled_ds)
+
+    # Assert that unscaled data is very close to the input data for scaling
+    np.testing.assert_allclose(unscaled_ds['temp'].values, new_ds['temp'].values, rtol=1e-5)
+    np.testing.assert_allclose(unscaled_ds['pressure'].values, new_ds['pressure'].values, rtol=1e-5)
+
+def test_scaler_unscale_raises_error_for_missing_features(scaler_instance_calculated):
+    ds_with_extra = xr.Dataset({'extra_var': (('x',), [1, 2])})
+    with pytest.raises(ValueError, match="Requesting to unscale variables that are not part of the scaler:"):
+        scaler_instance_calculated.unscale(ds_with_extra)
+
+# --- Test Scaler.save and Scaler.load ---
+
+def test_scaler_save_and_load(tmp_scaler_dir, scaler_instance_calculated, sample_dataset_basic):
+    scaler_instance_calculated.save()
+    scaler_file_path = tmp_scaler_dir / SCALER_FILE_NAME
+    assert scaler_file_path.exists()
+
+    loaded_scaler = Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=False, dataset=None)
+
+    assert loaded_scaler.scaler is not None
+    np.testing.assert_allclose(loaded_scaler.scaler['temp'].values, scaler_instance_calculated.scaler['temp'].values)
+    np.testing.assert_allclose(loaded_scaler.scaler['pressure'].values, scaler_instance_calculated.scaler['pressure'].values)
+
+    scaled_via_loaded = loaded_scaler.scale(sample_dataset_basic)
+    unscaled_via_loaded = loaded_scaler.unscale(scaled_via_loaded)
+    np.testing.assert_allclose(unscaled_via_loaded['temp'].values, sample_dataset_basic['temp'].values, rtol=1e-5)
+
+def test_scaler_save_raises_error_if_not_calculated(tmp_scaler_dir):
+    scaler = Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=True, dataset=None)
+    with pytest.raises(ValueError, match="You are trying to save a scaler that has not been computed."):
+        scaler.save()
+
+# --- NEW TESTS: `_check_zero_scale` interaction with `load` ---
+
+def test_scaler_load_from_file_raises_error_for_zero_scale(tmp_scaler_dir):
+    scaler_file_path = tmp_scaler_dir / SCALER_FILE_NAME
+    # Create a dummy scaler file with zero scale value
+    zero_scale_ds = xr.Dataset(
+        {'test_var': (('parameter',), np.array([0.0, 0.0, 1.0, 1.0]))}, # scale is 0
+        coords={'parameter': ['center', 'scale', 'mean', 'std']}
+    )
+    os.makedirs(tmp_scaler_dir, exist_ok=True)
+    with open(scaler_file_path, 'wb') as f:
+        zero_scale_ds.to_netcdf(f)
+
+    # Now try to load this scaler and expect a ValueError
+    with pytest.raises(ValueError, match="Zero scale values found for features:"):
+        Scaler(scaler_dir=tmp_scaler_dir, calculate_scaler=False, dataset=None)


### PR DESCRIPTION
This consolidates all data scaling functions to a single location in a dedicated object.

Touches functionality in training (BaseTrainer), testing (BaseTester), dataset (BaseDataset). Uncertainty sampling is affected because it requires an unscaled value for '0'. All child data classes in datazoo are affected because BaseDataset no longer accepts a scaler dictionary.  

Preserves all backward compatibility for old scaler files EXCEPT that it removes support for scaler files that are 2 generations old (these files have keys labeled "camels_attrs').