### PR TITLE
Added following features that can be directly declared in the config file

### DIFF
--- a/neuralhydrology/training/basetrainer.py
+++ b/neuralhydrology/training/basetrainer.py
@@ -354,7 +354,6 @@ class BaseTrainer(object):
             pbar.set_postfix_str(f"Loss: {loss.item():.4f}")
 
             self.experiment_logger.log_step(**{k: v.item() for k, v in all_losses.items()})
-          
     def _set_random_seeds(self):
         if self.cfg.seed is None:
             self.cfg.seed = int(np.random.uniform(low=0, high=1e6))

--- a/neuralhydrology/training/earlystopper.py
+++ b/neuralhydrology/training/earlystopper.py
@@ -1,46 +1,17 @@
 class EarlyStopper:
-    '''Stops training if validation loss doesn't improve for `patience` epochs,
-    unless the last round(patience/3) losses improved consecutively.'''
+    """Stops training if validation loss doesn't improve for `patience` epochs."""
 
-    def __init__(self, patience=5, min_delta=0):
-        self.patience = patience
-        self.min_delta = min_delta
-        self.counter = 0
-        self.consecutive_improvements = 0
-        self.min_validation_loss = float('inf')
-        self.previous_loss = float('inf')
+    def __init__(self, patience: int, min_delta: float):
+        self._patience = patience
+        self._min_delta = min_delta
+        self._counter = 0
+        self._min_validation_loss = float('inf')
 
-    def early_stop(self, validation_loss):
-        stop = False
-
-        # If loss improved from the previous epoch
-        if validation_loss < self.previous_loss - self.min_delta:
-            self.consecutive_improvements += 1
-            print(f"Loss improved. Consecutive improvements: {self.consecutive_improvements}")
+    def check_early_stopping(self, validation_loss: float) -> bool:
+        if validation_loss < self._min_validation_loss - self._min_delta:
+            self._min_validation_loss = validation_loss
+            self._counter = 0
         else:
-            self.consecutive_improvements = 0
+            self._counter += 1
 
-        # If new minimum loss is found
-        if validation_loss < self.min_validation_loss - self.min_delta:
-            self.min_validation_loss = validation_loss
-            self.counter = 0
-            print(f"New minimum validation loss: {self.min_validation_loss}. Counter reset.")
-        else:
-            # Only increment counter if no new min and not in the 1/3rd of patient batch improvement streak
-            if self.consecutive_improvements < int(round(self.patience / 3)):
-                self.counter += 1
-                print(f"No new min. Counter incremented to {self.counter}")   
-            elif self.consecutive_improvements < int(round(self.patience / 2)):
-                self.counter = 0
-                print(f"Consecutive improvements between 3 and 10. Counter reset to 0")
-            else:
-                self.counter = 0
-                self.min_validation_loss = validation_loss
-                print(f"Since it improved for 10 epochs consecutively, but is still not better than the min_validation, the min validation loss is set to the current loss: {validation_loss}")
-
-        if self.counter >= self.patience:
-            stop = True
-            print("Early stopping triggered.")
-
-        self.previous_loss = validation_loss
-        return stop
+        return self._counter >= self._patience

--- a/neuralhydrology/training/earlystopper.py
+++ b/neuralhydrology/training/earlystopper.py
@@ -1,0 +1,46 @@
+class EarlyStopper:
+    '''Stops training if validation loss doesn't improve for `patience` epochs,
+    unless the last round(patience/3) losses improved consecutively.'''
+
+    def __init__(self, patience=5, min_delta=0):
+        self.patience = patience
+        self.min_delta = min_delta
+        self.counter = 0
+        self.consecutive_improvements = 0
+        self.min_validation_loss = float('inf')
+        self.previous_loss = float('inf')
+
+    def early_stop(self, validation_loss):
+        stop = False
+
+        # If loss improved from the previous epoch
+        if validation_loss < self.previous_loss - self.min_delta:
+            self.consecutive_improvements += 1
+            print(f"Loss improved. Consecutive improvements: {self.consecutive_improvements}")
+        else:
+            self.consecutive_improvements = 0
+
+        # If new minimum loss is found
+        if validation_loss < self.min_validation_loss - self.min_delta:
+            self.min_validation_loss = validation_loss
+            self.counter = 0
+            print(f"New minimum validation loss: {self.min_validation_loss}. Counter reset.")
+        else:
+            # Only increment counter if no new min and not in the 1/3rd of patient batch improvement streak
+            if self.consecutive_improvements < int(round(self.patience / 3)):
+                self.counter += 1
+                print(f"No new min. Counter incremented to {self.counter}")   
+            elif self.consecutive_improvements < int(round(self.patience / 2)):
+                self.counter = 0
+                print(f"Consecutive improvements between 3 and 10. Counter reset to 0")
+            else:
+                self.counter = 0
+                self.min_validation_loss = validation_loss
+                print(f"Since it improved for 10 epochs consecutively, but is still not better than the min_validation, the min validation loss is set to the current loss: {validation_loss}")
+
+        if self.counter >= self.patience:
+            stop = True
+            print("Early stopping triggered.")
+
+        self.previous_loss = validation_loss
+        return stop

--- a/neuralhydrology/utils/config.py
+++ b/neuralhydrology/utils/config.py
@@ -915,7 +915,36 @@ class Config(object):
             Level of verbosity.
         """
         return self._cfg.get("verbose", 1)
+    
+    @property
+    def early_stopping(self) -> bool:
+        """Whether to use early stopping. Defaults to False if not set."""
+        return self._cfg.get("early_stopping", False)
 
+    @property
+    def patience_early_stopping(self) -> int:
+        """Number of epochs with no improvement before stopping. Defaults to 5 if not set. Done in basetrainer.py class with logged info."""
+        return self._cfg.get("patience_early_stopping", 0)
+    
+    @property
+    def minimum_epochs_before_early_stopping(self) -> int:
+        """Minimum number of epochs before early stopping can be triggered. Defaults to 5 if not set. Done in basetrainer.py class with logged info."""
+        return self._cfg.get("minimum_epochs_before_early_stopping", 0)
+    
+    @property
+    def dynamic_learning_rate(self) -> bool:
+        """Whether to use  dynamic learning rate. Defaults to False if not set."""
+        return self._cfg.get("dynamic_learning_rate", False)
+    
+    @property
+    def patience_dynamic_learning_rate(self) -> int:
+        """Number of epochs with no improvement before reducing learning rate. Defaults to 3 if not set. Done in basetrainer.py class with logged info."""
+        return self._cfg.get("patience_dynamic_learning_rate", 0)
+    @property
+    def factor_dynamic_learning_rate(self) -> float:
+        """Factor by which to reduce learning rate. Defaults to 0.1 if not set. Done in basetrainer.py class with logged info."""
+        return self._cfg.get("factor_dynamic_learning_rate", 0)
+    
     def _get_embedding_spec(self, embedding_spec: dict) -> dict:
         if isinstance(embedding_spec, bool) and embedding_spec:  #
             msg = [

--- a/neuralhydrology/utils/config.py
+++ b/neuralhydrology/utils/config.py
@@ -919,31 +919,48 @@ class Config(object):
     @property
     def early_stopping(self) -> bool:
         """Whether to use early stopping. Defaults to False if not set."""
-        return self._cfg.get("early_stopping", False)
+        if self._cfg.get("validate_every", None) == 1:
+            return self._cfg.get("early_stopping", False)
+        else:
+            raise ValueError(
+                "Early stopping can only be used if validation is performed every epoch (validate_every=1). "
+                "Set validate_every=1 in the config to use early stopping."
+            )
 
     @property
     def patience_early_stopping(self) -> int:
-        """Number of epochs with no improvement before stopping. Defaults to 5 if not set. Done in basetrainer.py class with logged info."""
-        return self._cfg.get("patience_early_stopping", 0)
-    
+        """Number of epochs with no improvement before stopping."""
+        if self._cfg.get("early_stopping", False):
+            return self._get_value_verbose("patience_early_stopping")
+        
     @property
     def minimum_epochs_before_early_stopping(self) -> int:
-        """Minimum number of epochs before early stopping can be triggered. Defaults to 5 if not set. Done in basetrainer.py class with logged info."""
-        return self._cfg.get("minimum_epochs_before_early_stopping", 0)
+        """Minimum number of epochs before early stopping can be triggered."""
+        if self._cfg.get("early_stopping", False):
+            return self._get_value_verbose("minimum_epochs_before_early_stopping")
     
     @property
     def dynamic_learning_rate(self) -> bool:
         """Whether to use  dynamic learning rate. Defaults to False if not set."""
-        return self._cfg.get("dynamic_learning_rate", False)
+        if self._cfg.get("validate_every", None) == 1:
+            return self._cfg.get("dynamic_learning_rate", False)
+        else:
+            raise ValueError(
+                "Dynamic learning rate can only be used if validation is performed every epoch (validate_every=1). "
+                "Set validate_every=1 in the config to use dynamic learning rate."
+            )
     
     @property
     def patience_dynamic_learning_rate(self) -> int:
-        """Number of epochs with no improvement before reducing learning rate. Defaults to 3 if not set. Done in basetrainer.py class with logged info."""
-        return self._cfg.get("patience_dynamic_learning_rate", 0)
+        """Number of epochs with no improvement before reducing learning rate."""
+        if self._cfg.get("dynamic_learning_rate", False):
+            return self._get_value_verbose("patience_dynamic_learning_rate")
+        
     @property
     def factor_dynamic_learning_rate(self) -> float:
-        """Factor by which to reduce learning rate. Defaults to 0.1 if not set. Done in basetrainer.py class with logged info."""
-        return self._cfg.get("factor_dynamic_learning_rate", 0)
+        """Factor by which to reduce learning rate."""
+        if self._cfg.get("dynamic_learning_rate", False):
+            return self._get_value_verbose("factor_dynamic_learning_rate")
     
     def _get_embedding_spec(self, embedding_spec: dict) -> dict:
         if isinstance(embedding_spec, bool) and embedding_spec:  #

--- a/neuralhydrology/utils/config.py
+++ b/neuralhydrology/utils/config.py
@@ -919,47 +919,45 @@ class Config(object):
     @property
     def early_stopping(self) -> bool:
         """Whether to use early stopping. Defaults to False if not set."""
-        if self._cfg.get("validate_every", None) == 1:
+        if self.validate_every == 1:
             return self._cfg.get("early_stopping", False)
-        else:
-            raise ValueError(
-                "Early stopping can only be used if validation is performed every epoch (validate_every=1). "
-                "Set validate_every=1 in the config to use early stopping."
-            )
+        raise ValueError(
+            "Early stopping can only be used if validation is performed every epoch (validate_every=1). "
+            "Set validate_every=1 in the config to use early stopping."
+        )
 
     @property
     def patience_early_stopping(self) -> int:
         """Number of epochs with no improvement before stopping."""
-        if self._cfg.get("early_stopping", False):
+        if self.early_stopping:
             return self._get_value_verbose("patience_early_stopping")
         
     @property
     def minimum_epochs_before_early_stopping(self) -> int:
         """Minimum number of epochs before early stopping can be triggered."""
-        if self._cfg.get("early_stopping", False):
+        if self.early_stopping:
             return self._get_value_verbose("minimum_epochs_before_early_stopping")
     
     @property
     def dynamic_learning_rate(self) -> bool:
         """Whether to use  dynamic learning rate. Defaults to False if not set."""
-        if self._cfg.get("validate_every", None) == 1:
+        if self.validate_every == 1:
             return self._cfg.get("dynamic_learning_rate", False)
-        else:
-            raise ValueError(
-                "Dynamic learning rate can only be used if validation is performed every epoch (validate_every=1). "
-                "Set validate_every=1 in the config to use dynamic learning rate."
-            )
+        raise ValueError(
+            "Dynamic learning rate can only be used if validation is performed every epoch (validate_every=1). "
+            "Set validate_every=1 in the config to use dynamic learning rate."
+        )
     
     @property
     def patience_dynamic_learning_rate(self) -> int:
         """Number of epochs with no improvement before reducing learning rate."""
-        if self._cfg.get("dynamic_learning_rate", False):
+        if self.dynamic_learning_rate:
             return self._get_value_verbose("patience_dynamic_learning_rate")
         
     @property
     def factor_dynamic_learning_rate(self) -> float:
         """Factor by which to reduce learning rate."""
-        if self._cfg.get("dynamic_learning_rate", False):
+        if self.dynamic_learning_rate:
             return self._get_value_verbose("factor_dynamic_learning_rate")
     
     def _get_embedding_spec(self, embedding_spec: dict) -> dict:


### PR DESCRIPTION
🚀 New Configuration Options

1. early_stopping
   - Type: bool
   - Default: False
   - Description: When set to true, training will monitor the loss curve and terminate early once it stops improving.

2. minimum_epochs_before_early_stopping
   - Type: int
   - Default: 5
   - Description: Guarantees that at least this many epochs run before early stopping can kick in. Prevents premature halting on very noisy initial losses.

3. patience_early_stopping
   - Type: int
   - Default: 5
   - Description: Number of epochs with no improvement in training loss after which early stopping triggers. Internally, the implementation still tracks small consecutive improvements to avoid stopping on temporary plateaus.

4. dynamic_learning_rate
   - Type: bool
   - Default: False
   - Description: Enables automatic decay of the learning rate during training based on observed loss trends.

5. factor_dynamic_learning_rate
   - Type: float
   - Default: 0.1
   - Description: When dynamic learning rate is active, multiplies the current learning rate by this factor each time decay is triggered.

6. patience_dynamic_learning_rate
   - Type: int
   - Default: 1
   - Description: Number of epochs with no loss improvement before reducing the learning rate by factor_dynamic_learning_rate.

🎯 Benefits & Value

- More Robust Training
  Early stopping with a configurable “warm‑up” (minimum_epochs_before_early_stopping) and patience window prevents both under‑ and over‑training. Users can let long runs self‑terminate once convergence plateaus, saving compute and guarding against overfitting.

- Flexible Hyperparameter Control
  By separating “minimum epochs” from “patience,” and exposing both as integers, users can finely tune how aggressively the model stops. You no longer need to hack your training script for a two‑stage stopping strategy—everything lives in the config.

- Adaptive Learning Rates for Faster Convergence
  Dynamic LR decay kicks in exactly when the loss plateaus (per patience_dynamic_learning_rate), reducing manual LR-scheduling boilerplate. factor_dynamic_learning_rate gives full control over decay magnitude.

- Out‑of‑the‑Box Best Practices
These features implement widely-adopted training heuristics (early stopping, LR decay) in a plug‑and‑play way—no extra callbacks or custom code required. Newcomers and experts alike get a more reliable, reproducible training loop.
