### PR TITLE
Add xLSTM backbone to neuralhydrology

### DIFF
--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -252,6 +252,17 @@ These are used if ``model == transformer``.
 -  ``transformer_dropout``: Dropout used in transformer encoder layers.
 -  ``transformer_nhead``: Number of parallel transformer heads.
 
+XLSTM settings
+~~~~~~~~~~~~~~
+These are used if ``model == x_lstm``.
+
+-  ``xlstm_num_blocks``: number of stacked xLSTM blocks
+-  ``xlstm_slstm_at``: indices of blocks of scalar-memory
+-  ``xlstm_heads``: number of heads
+-  ``xlstm_kernel_size``: convolutional kernel size
+-  ``xlstm_proj_factor``: projection factor
+
+
 ODE-LSTM settings
 ~~~~~~~~~~~~~~~~~
 

--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -199,6 +199,23 @@ The model requires the following hyperparameters specified in the config file:
 * ``transformer_dropout``: dropout in the feedforward networks between self-attention heads.
 * ``transformer_nlayers``: number of stacked self-attention + feedforward layers.
 
+XLSTM
+^^^^^^^^^^^
+:py:class:`neuralhydrology.modelzoo.x_lstm.XLSTM` is a recurrent architecture using the official implementation of backbone
+https://github.com/NX-AI/xlstm from `Beck et al. (2024) <https://arxiv.org/abs/2405.04517>`_.
+
+The ``xlstm`` package is the required dependency for XLSTM.
+
+There are five hyperparameters which can be set in the config file:
+
+* ``xlstm_num_blocks``: number of stacked xLSTM blocks (Default is set to 1)
+* ``xlstm_slstm_at``: indices of blocks of scalar-memory (Default is set to position [0])
+* ``xlstm_heads``: number of heads (Default is set to 2)
+* ``xlstm_kernel_size``: convolutional kernel size (Default is set to 4)
+* ``xlstm_proj_factor``: projection factor (Default is set to 1.3)
+
+
+
 Handoff-Forecast-LSTM
 ^^^^^^^^^^^^^^^^^^^^^
 :py:class:`neuralhydrology.modelzoo.handoff_forecast_lstm.HandoffForecastLSTM` is a forecasting model that uses a state-handoff to transition 

--- a/neuralhydrology/modelzoo/__init__.py
+++ b/neuralhydrology/modelzoo/__init__.py
@@ -20,6 +20,8 @@ from neuralhydrology.modelzoo.stacked_forecast_lstm import StackedForecastLSTM
 from neuralhydrology.modelzoo.transformer import Transformer
 from neuralhydrology.utils.config import Config
 
+from neuralhydrology.modelzoo.x_lstm import XLSTM
+
 SINGLE_FREQ_MODELS = [
     "cudalstm",
     "ealstm", 
@@ -33,7 +35,8 @@ SINGLE_FREQ_MODELS = [
     "handoff_forecast_lstm",
     "sequential_forecast_lstm",
     "multihead_forecast_lstm",
-    "stacked_forecast_lstm"
+    "stacked_forecast_lstm",
+    "x_lstm"
 ]
 AUTOREGRESSIVE_MODELS = ['arlstm']
 
@@ -62,6 +65,14 @@ def get_model(cfg: Config) -> nn.Module:
 
     if cfg.model.lower() == "arlstm":
         model = ARLSTM(cfg=cfg)
+
+
+
+    elif cfg.model.lower() == "x_lstm":
+        model = XLSTM(cfg=cfg)
+
+
+
     elif cfg.model.lower() == "cudalstm":
         model = CudaLSTM(cfg=cfg)
     elif cfg.model.lower() == "ealstm":

--- a/neuralhydrology/modelzoo/x_lstm.py
+++ b/neuralhydrology/modelzoo/x_lstm.py
@@ -1,0 +1,134 @@
+from typing import Dict
+import torch
+import torch.nn as nn
+
+from neuralhydrology.modelzoo.inputlayer import InputLayer
+from neuralhydrology.modelzoo.head import get_head
+from neuralhydrology.modelzoo.basemodel import BaseModel
+from neuralhydrology.utils.config import Config
+
+# -------- Auto-setup CUDA env for xLSTM --------
+import os
+import shutil
+if "CUDA_HOME" not in os.environ:
+    nvcc_path = shutil.which("nvcc")
+    if nvcc_path is not None:
+        os.environ["CUDA_HOME"] = os.path.dirname(os.path.dirname(nvcc_path))
+
+if "XLSTM_EXTRA_INCLUDE_PATHS" not in os.environ:
+    cuda_home = os.environ.get("CUDA_HOME")
+    if cuda_home is not None:
+        include_path = os.path.join(cuda_home, "include")
+        if os.path.exists(include_path):
+            os.environ["XLSTM_EXTRA_INCLUDE_PATHS"] = include_path
+# -----------------------------------------------
+
+try:
+    from xlstm import (
+        xLSTMBlockStack,
+        xLSTMBlockStackConfig,
+        mLSTMBlockConfig,
+        mLSTMLayerConfig,
+        sLSTMBlockConfig,
+        sLSTMLayerConfig,
+        FeedForwardConfig,
+    )
+    XLSTM_AVAILABLE = True
+except ModuleNotFoundError:
+    XLSTM_AVAILABLE = False
+
+
+class XLSTM(BaseModel):
+    """Extended Long Short-Term Memory (xLSTM) backbone model class, which relies on https://github.com/NX-AI/xlstm
+    
+    This class implements the xLSTM backbone, consisting of stacked mLSTM and sLSTM blocks. 
+    A transition layer (linear projection) ensures that the input feature dimension matches the hidden size required by the xLSTM stack. 
+
+    Parameters
+    ----------
+    cfg : Config
+        The run configuration.
+    """
+    
+    # specify submodules of the model that can later be used for finetuning. Names must match class attributes
+    module_parts = ["embedding_net", "transition_layer", "xlstm", "dropout", "head"]
+
+    def __init__(self, cfg: Config):
+        super(XLSTM, self).__init__(cfg=cfg)
+
+        self.embedding_net = InputLayer(cfg)
+
+        # using a linear layer to move from the emdedded_layer dims to the specified hidden size
+        self.transition_layer = nn.Linear(self.embedding_net.output_size, self.cfg.hidden_size)
+
+        if not XLSTM_AVAILABLE:
+            raise ModuleNotFoundError("xlstm, and dependencies, required. Please install the xlstm package\
+                                       from https://github.com/NX-AI/xLSTM (and ensure CUDA headers are available).")
+        else:                
+            xlstm_cfg = xLSTMBlockStackConfig(
+                mlstm_block=mLSTMBlockConfig(
+                    mlstm=mLSTMLayerConfig(
+                        conv1d_kernel_size=cfg.xlstm_kernel_size,
+                        qkv_proj_blocksize=4,
+                        num_heads=cfg.xlstm_heads,
+                    )
+                ),
+                slstm_block=sLSTMBlockConfig(
+                    slstm=sLSTMLayerConfig(
+                        backend="cuda",           
+                        num_heads=cfg.xlstm_heads,
+                        conv1d_kernel_size=cfg.xlstm_kernel_size,
+                        bias_init="powerlaw_blockdependent",
+                    ),
+                    feedforward=FeedForwardConfig(
+                        proj_factor=cfg.xlstm_proj_factor,
+                        act_fn="gelu",
+                    ),
+                ),
+                context_length = cfg.seq_length, 
+                num_blocks = cfg.xlstm_num_blocks,
+                embedding_dim = cfg.hidden_size,      
+                slstm_at = cfg.xlstm_slstm_at,
+            )
+
+            self.xlstm = xLSTMBlockStack(xlstm_cfg)
+
+        self.dropout = nn.Dropout(p=cfg.output_dropout)
+
+        self.head = get_head(cfg=cfg, n_in=cfg.hidden_size, n_out=self.output_size)
+
+    def forward(self, data: dict[str, torch.Tensor | dict[str, torch.Tensor]]) -> Dict[str, torch.Tensor]:
+        """Perform a forward pass on the xlstm model.
+
+        Parameters
+        ----------
+        data : dict[str, torch.Tensor | dict[str, torch.Tensor]]
+            Dictionary, containing input features as key-value pairs.
+
+        Returns
+        -------
+        Dict[str, torch.Tensor]
+            - 'y_hat': model predictions of shape [batch size, sequence length, number of target variables].
+        """
+        # possibly pass dynamic and static inputs through embedding layers, then concatenate them
+        x_d = self.embedding_net(data)
+
+        # reshaping dimensions to what xlstm expects [batch size, sequence length, hidden size]:
+        x_d = x_d.transpose(0, 1)
+        x_d_transition = self.transition_layer(x_d)
+
+        xlstm_output = self.xlstm(x_d_transition)
+
+        pred = {'y_hat': xlstm_output}
+        pred.update(self.head(self.dropout(xlstm_output)))
+        return pred
+
+
+    @staticmethod
+    def _as_int(val):
+        """NH seq_length could be dict like {'1h': 24}, here convert to int"""
+        if isinstance(val, int):
+            return val
+        if isinstance(val, dict):
+            return next(iter(val.values()))
+        raise TypeError(f"Expected int or single-valued dict, got {type(val)}")


### PR DESCRIPTION
This PR adds the xLSTM model to NeuralHydrology.

It has been tested locally on daily and hourly data, but it currently does not support multiple timescales.

- Implemented `x_lstm.py` with xLSTM architecture from https://github.com/NX-AI/xlstm based on Beck et al. (2024).
- Registered the model in `modelzoo/__init__.py`.
- Includes configuration options: (`xlstm_num_blocks`, `xlstm_slstm_at`, `xlstm_heads`, `xlstm_kernel_size`, `xlstm_proj_factor`), in `utils/config.py`
- Added documentation for model and configurations rst files in `docs/`

This is my first time contributing via Git. Please let me know if anything in this PR does not follow the correct procedure. Thanks!
