### PR TITLE
XLSTM Fix: add automatic CUDA_LIB path detection

### DIFF
--- a/neuralhydrology/modelzoo/x_lstm.py
+++ b/neuralhydrology/modelzoo/x_lstm.py
@@ -17,20 +17,18 @@ if "CUDA_HOME" not in os.environ:
     if nvcc_path is not None:
         os.environ["CUDA_HOME"] = os.path.dirname(os.path.dirname(nvcc_path))
 
-if "CUDA_LIB" not in os.environ:
-    cuda_home = os.environ.get("CUDA_HOME")
-    if cuda_home:
-        lib_candidates = [os.path.join(cuda_home, "lib64"),
-                          os.path.join(cuda_home, "lib"),
-                          os.path.join(cuda_home, "lib/x86_64-linux-gnu"),]
-        for path in lib_candidates:
-            if os.path.exists(path):
-                os.environ["CUDA_LIB"] = path
+cuda_home = os.environ.get("CUDA_HOME")
+if cuda_home:
+    cuda_home = os.path.expandvars(os.path.expanduser(cuda_home))
+
+    if "CUDA_LIB" not in os.environ:
+        for subdir in ("lib64", "lib", "lib/x86_64-linux-gnu"):
+            lib_path = os.path.join(cuda_home, subdir)
+            if os.path.exists(lib_path):
+                os.environ["CUDA_LIB"] = lib_path
                 break
 
-if "XLSTM_EXTRA_INCLUDE_PATHS" not in os.environ:
-    cuda_home = os.environ.get("CUDA_HOME")
-    if cuda_home is not None:
+    if "XLSTM_EXTRA_INCLUDE_PATHS" not in os.environ:
         include_path = os.path.join(cuda_home, "include")
         if os.path.exists(include_path):
             os.environ["XLSTM_EXTRA_INCLUDE_PATHS"] = include_path


### PR DESCRIPTION
This PR adds a small follow-up fix to the recently merged xLSTM model. 
It improves CUDA environment setup by automatically detecting the CUDA_LIB path, this resolves the error that could occur when CUDA_LIB was missing in environmental variables.

Apologies for submitting another PR so soon after the previous merge. 
During further testing, I found that evaluation runs may fail to locate CUDA libraries if the environment variable CUDA_LIB is not explicitly set.

**Changes:**
Added automatic CUDA_LIB detection in x_lstm.py
Supported common library directories (lib64, lib, lib/x86_64-linux-gnu)