### PR TITLE
Fixes #268

### DIFF
--- a/neuralhydrology/utils/nh_results_ensemble.py
+++ b/neuralhydrology/utils/nh_results_ensemble.py
@@ -105,10 +105,8 @@ def _create_ensemble(results_files: List[Path], frequencies: List[str], config: 
             # create datetime range at the current frequency, removing time steps that are not being predicted
             frequency_factor = int(get_frequency_factor(lowest_freq, freq))
             # make sure the last day is fully contained in the range
-            freq_date_range = pd.date_range(start=ensemble_xr.coords['date'].values[0],
-                                            end=ensemble_xr.coords['date'].values[-1] \
-                                                + pd.Timedelta(days=1, seconds=-1),
-                                            freq=freq)
+            freq_date_range = pd.date_range(start=ensemble_xr.coords['date'].values[0], 
+                                            periods=len(ensemble_xr.coords['date']) * frequency_factor, freq=freq)
             mask = np.ones(frequency_factor).astype(bool)
             mask[:-len(ensemble_xr.coords['time_step'])] = False
             freq_date_range = freq_date_range[np.tile(mask, len(ensemble_xr.coords['date']))]


### PR DESCRIPTION
This PR fixes an issue in the date range generation logic within the ensemble processing module.
Previously, the code used a fixed-length assumption for constructing freq_date_range, which could fail when the input data had non-daily time scales.
The logic is now updated to:
```
freq_date_range = pd.date_range(
    start=ensemble_xr.coords['date'].values[0],
    periods=len(ensemble_xr.coords['date']) * frequency_factor,
    freq=freq,
)
```
Related Issue
Fixes #268 
