### PR TITLE
Fix xLSTM configuration parsing and update default settings

### DIFF
--- a/docs/source/usage/models.rst
+++ b/docs/source/usage/models.rst
@@ -208,9 +208,9 @@ The ``xlstm`` package is the required dependency for XLSTM.
 
 There are five hyperparameters which can be set in the config file:
 
-* ``xlstm_num_blocks``: number of stacked xLSTM blocks (Default is set to 1)
-* ``xlstm_slstm_at``: indices of blocks of scalar-memory (Default is set to position [0])
-* ``xlstm_heads``: number of heads (Default is set to 2)
+* ``xlstm_num_blocks``: number of stacked xLSTM blocks (Default is set to 2)
+* ``xlstm_slstm_at``: indices of blocks of scalar-memory (Default is set to position [1])
+* ``xlstm_heads``: number of heads (Default is set to 1)
 * ``xlstm_kernel_size``: convolutional kernel size (Default is set to 4)
 * ``xlstm_proj_factor``: projection factor (Default is set to 1.3)
 

--- a/neuralhydrology/modelzoo/x_lstm.py
+++ b/neuralhydrology/modelzoo/x_lstm.py
@@ -91,7 +91,7 @@ class XLSTM(BaseModel):
                     act_fn="gelu",
                 ),
             ),
-            context_length = cfg.seq_length, 
+            context_length = self._as_int(cfg.seq_length),
             num_blocks = cfg.xlstm_num_blocks,
             embedding_dim = cfg.hidden_size,      
             slstm_at = cfg.xlstm_slstm_at,

--- a/neuralhydrology/utils/config.py
+++ b/neuralhydrology/utils/config.py
@@ -986,15 +986,15 @@ class Config(object):
 
     @property
     def xlstm_num_blocks(self) -> int:
-        return self._cfg.get("xlstm_num_blocks", 1)
+        return self._cfg.get("xlstm_num_blocks", 2)
     
     @property
     def xlstm_slstm_at(self) -> List[int]:
-        return self._as_default_list(self._cfg.get("xlstm_slstm_at", [0]))
+        return self._as_default_list(self._cfg.get("xlstm_slstm_at", [1]))
     
     @property
     def xlstm_heads(self) -> int:
-        return self._cfg.get("xlstm_heads", 2)
+        return self._cfg.get("xlstm_heads", 1)
     
     @property
     def xlstm_kernel_size(self) -> int:


### PR DESCRIPTION
This PR refines the xLSTM implementation to ensure parameter consistency and alignment with the original paper example.

Key Updates
1. Use the _as_int conversion to ensure the sequence length parameter passed to the xLSTM configuration is properly cast to integer types.
2. Adjusted the default configuration to match the example in the original xLSTM paper, which uses one mLSTM block and one sLSTM block.

Apologies for another follow-up right after the previous PR — the issue wasn’t caught during earlier testing. Sorry for any inconvenience this may have caused.