### PR TITLE
Add probabilistic forecast evaluation metrics

### DIFF
--- a/docs/source/usage/config.rst
+++ b/docs/source/usage/config.rst
@@ -103,7 +103,10 @@ Validation settings
    where each key-value pair corresponds to one target variable and
    the metrics that should be computed for this target. Like this,
    it is possible to compute different metrics per target during 
-   validation and/or evaluation after the training.
+   validation and/or evaluation after the training. The sample-based
+   metrics ``CRPS``, ``PICP``, and ``MPIW`` are available for
+   probabilistic predictions, e.g., from ``gmm``, ``cmal``, ``umal``,
+   or Monte-Carlo dropout.
 
 -  ``save_validation_results``: True/False, if True, stores the
    validation results to disk as a pickle file. Otherwise they are only

--- a/neuralhydrology/evaluation/metrics.py
+++ b/neuralhydrology/evaluation/metrics.py
@@ -12,8 +12,13 @@ from neuralhydrology.utils.errors import AllNaNError
 LOGGER = logging.getLogger(__name__)
 
 
-def get_available_metrics() -> List[str]:
+def get_available_metrics(include_probabilistic: bool = False) -> List[str]:
     """Get list of available metrics.
+
+    Parameters
+    ----------
+    include_probabilistic : bool, optional
+        If True, include metrics that require forecast samples. By default False.
 
     Returns
     -------
@@ -24,6 +29,8 @@ def get_available_metrics() -> List[str]:
         "NSE", "MSE", "RMSE", "KGE", "Alpha-NSE", "Pearson-r", "Beta-KGE", "Beta-NSE", "FHV", "FMS", "FLV",
         "Peak-Timing", "Missed-Peaks", "Peak-MAPE"
     ]
+    if include_probabilistic:
+        metrics += ["CRPS", "PICP", "MPIW"]
     return metrics
 
 
@@ -47,6 +54,21 @@ def _mask_valid(obs: DataArray, sim: DataArray) -> Tuple[DataArray, DataArray]:
 
 def _get_fdc(da: DataArray) -> np.ndarray:
     return da.sortby(da, ascending=False).values
+
+
+def _validate_ensemble_inputs(obs: DataArray, sim: DataArray):
+    if 'samples' not in sim.dims:
+        raise RuntimeError("Ensemble metrics require simulations with a 'samples' dimension.")
+    _validate_inputs(obs, sim.mean(dim='samples'))
+
+
+def _mask_valid_ensemble(obs: DataArray, sim: DataArray) -> Tuple[DataArray, DataArray]:
+    idx = (~obs.isnull()) & sim.notnull().all(dim='samples')
+
+    obs = obs[idx]
+    sim = sim.where(idx, drop=True)
+
+    return obs, sim
 
 
 def nse(obs: DataArray, sim: DataArray) -> float:
@@ -755,6 +777,119 @@ def mean_absolute_percentage_peak_error(obs: DataArray, sim: DataArray) -> float
     return peak_mape
 
 
+def crps(obs: DataArray, sim: DataArray) -> float:
+    r"""Calculate the ensemble approximation of the Continuous Ranked Probability Score.
+
+    CRPS evaluates the full predictive distribution and reduces to the mean absolute error for deterministic
+    forecasts. Lower values indicate better probabilistic forecasts.
+
+    .. math::
+        \text{CRPS} = \frac{1}{T}\sum_{t=1}^T
+        \left(\frac{1}{M}\sum_{m=1}^M |x_{t,m} - y_t|
+        - \frac{1}{2M^2}\sum_{m=1}^M\sum_{j=1}^M |x_{t,m} - x_{t,j}|\right),
+
+    where :math:`x_{t,m}` are forecast samples and :math:`y_t` are observations.
+
+    Parameters
+    ----------
+    obs : DataArray
+        Observed time series.
+    sim : DataArray
+        Simulated samples with a ``samples`` dimension.
+
+    Returns
+    -------
+    float
+        Continuous Ranked Probability Score.
+    """
+    _validate_ensemble_inputs(obs, sim)
+
+    obs, sim = _mask_valid_ensemble(obs, sim)
+    if len(obs) < 1:
+        return np.nan
+
+    samples = np.sort(sim.transpose(..., 'samples').values, axis=-1)
+    observations = obs.values[..., None]
+    n_samples = samples.shape[-1]
+
+    absolute_error = np.mean(np.abs(samples - observations), axis=-1)
+    weights = 2 * np.arange(1, n_samples + 1) - n_samples - 1
+    ensemble_spread = np.sum(weights * samples, axis=-1) / n_samples**2
+
+    return float(np.mean(absolute_error - ensemble_spread))
+
+
+def picp(obs: DataArray, sim: DataArray, alpha: float = 0.1) -> float:
+    r"""Calculate prediction interval coverage probability.
+
+    PICP is the fraction of observations that fall inside the central ``1 - alpha`` prediction interval. For the
+    default ``alpha=0.1``, the metric evaluates the 90% prediction interval.
+
+    Parameters
+    ----------
+    obs : DataArray
+        Observed time series.
+    sim : DataArray
+        Simulated samples with a ``samples`` dimension.
+    alpha : float, optional
+        Size of the excluded probability mass, by default 0.1.
+
+    Returns
+    -------
+    float
+        Fraction of observations inside the prediction interval.
+    """
+    if (alpha <= 0) or (alpha >= 1):
+        raise ValueError("alpha has to be in range ]0,1[")
+
+    _validate_ensemble_inputs(obs, sim)
+
+    obs, sim = _mask_valid_ensemble(obs, sim)
+    if len(obs) < 1:
+        return np.nan
+
+    lower = sim.quantile(alpha / 2, dim='samples')
+    upper = sim.quantile(1 - alpha / 2, dim='samples')
+
+    coverage = (obs >= lower) & (obs <= upper)
+    return float(coverage.mean())
+
+
+def mpiw(obs: DataArray, sim: DataArray, alpha: float = 0.1) -> float:
+    r"""Calculate mean prediction interval width.
+
+    MPIW is the average width of the central ``1 - alpha`` prediction interval. For the default ``alpha=0.1``, the
+    metric evaluates the 90% prediction interval.
+
+    Parameters
+    ----------
+    obs : DataArray
+        Observed time series.
+    sim : DataArray
+        Simulated samples with a ``samples`` dimension.
+    alpha : float, optional
+        Size of the excluded probability mass, by default 0.1.
+
+    Returns
+    -------
+    float
+        Mean prediction interval width.
+    """
+    if (alpha <= 0) or (alpha >= 1):
+        raise ValueError("alpha has to be in range ]0,1[")
+
+    _validate_ensemble_inputs(obs, sim)
+
+    obs, sim = _mask_valid_ensemble(obs, sim)
+    if len(obs) < 1:
+        return np.nan
+
+    lower = sim.quantile(alpha / 2, dim='samples')
+    upper = sim.quantile(1 - alpha / 2, dim='samples')
+
+    return float((upper - lower).mean())
+
+
 def calculate_all_metrics(obs: DataArray,
                           sim: DataArray,
                           resolution: str = "1D",
@@ -784,21 +919,31 @@ def calculate_all_metrics(obs: DataArray,
     """
     _check_all_nan(obs, sim)
 
+    sim_mean = sim.mean(dim='samples') if 'samples' in sim.dims else sim
+
     results = {
-        "NSE": nse(obs, sim),
-        "MSE": mse(obs, sim),
-        "RMSE": rmse(obs, sim),
-        "KGE": kge(obs, sim),
-        "Alpha-NSE": alpha_nse(obs, sim),
-        "Beta-KGE": beta_kge(obs, sim),
-        "Beta-NSE": beta_nse(obs, sim),
-        "Pearson-r": pearsonr(obs, sim),
-        "FHV": fdc_fhv(obs, sim),
-        "FMS": fdc_fms(obs, sim),
-        "FLV": fdc_flv(obs, sim),
-        "Peak-Timing": mean_peak_timing(obs, sim, resolution=resolution, datetime_coord=datetime_coord),
-        "Peak-MAPE": mean_absolute_percentage_peak_error(obs, sim)
+        "NSE": nse(obs, sim_mean),
+        "MSE": mse(obs, sim_mean),
+        "RMSE": rmse(obs, sim_mean),
+        "KGE": kge(obs, sim_mean),
+        "Alpha-NSE": alpha_nse(obs, sim_mean),
+        "Beta-KGE": beta_kge(obs, sim_mean),
+        "Beta-NSE": beta_nse(obs, sim_mean),
+        "Pearson-r": pearsonr(obs, sim_mean),
+        "FHV": fdc_fhv(obs, sim_mean),
+        "FMS": fdc_fms(obs, sim_mean),
+        "FLV": fdc_flv(obs, sim_mean),
+        "Peak-Timing": mean_peak_timing(obs, sim_mean, resolution=resolution, datetime_coord=datetime_coord),
+        "Missed-Peaks": missed_peaks(obs, sim_mean, resolution=resolution, datetime_coord=datetime_coord),
+        "Peak-MAPE": mean_absolute_percentage_peak_error(obs, sim_mean)
     }
+
+    if 'samples' in sim.dims:
+        results.update({
+            "CRPS": crps(obs, sim),
+            "PICP": picp(obs, sim),
+            "MPIW": mpiw(obs, sim)
+        })
 
     return results
 
@@ -834,40 +979,55 @@ def calculate_metrics(obs: DataArray,
         If all observations or all simulations are NaN.
     """
     if 'all' in metrics:
-        return calculate_all_metrics(obs, sim, resolution=resolution)
+        return calculate_all_metrics(obs, sim, resolution=resolution, datetime_coord=datetime_coord)
 
     _check_all_nan(obs, sim)
 
     values = {}
     for metric in metrics:
+        sim_metric = sim.mean(dim='samples') if 'samples' in sim.dims and metric.lower() not in [
+            'crps', 'picp', 'mpiw'
+        ] else sim
         if metric.lower() == "nse":
-            values["NSE"] = nse(obs, sim)
+            values["NSE"] = nse(obs, sim_metric)
         elif metric.lower() == "mse":
-            values["MSE"] = mse(obs, sim)
+            values["MSE"] = mse(obs, sim_metric)
         elif metric.lower() == "rmse":
-            values["RMSE"] = rmse(obs, sim)
+            values["RMSE"] = rmse(obs, sim_metric)
         elif metric.lower() == "kge":
-            values["KGE"] = kge(obs, sim)
+            values["KGE"] = kge(obs, sim_metric)
         elif metric.lower() == "alpha-nse":
-            values["Alpha-NSE"] = alpha_nse(obs, sim)
+            values["Alpha-NSE"] = alpha_nse(obs, sim_metric)
         elif metric.lower() == "beta-kge":
-            values["Beta-KGE"] = beta_kge(obs, sim)
+            values["Beta-KGE"] = beta_kge(obs, sim_metric)
         elif metric.lower() == "beta-nse":
-            values["Beta-NSE"] = beta_nse(obs, sim)
+            values["Beta-NSE"] = beta_nse(obs, sim_metric)
         elif metric.lower() == "pearson-r":
-            values["Pearson-r"] = pearsonr(obs, sim)
+            values["Pearson-r"] = pearsonr(obs, sim_metric)
         elif metric.lower() == "fhv":
-            values["FHV"] = fdc_fhv(obs, sim)
+            values["FHV"] = fdc_fhv(obs, sim_metric)
         elif metric.lower() == "fms":
-            values["FMS"] = fdc_fms(obs, sim)
+            values["FMS"] = fdc_fms(obs, sim_metric)
         elif metric.lower() == "flv":
-            values["FLV"] = fdc_flv(obs, sim)
+            values["FLV"] = fdc_flv(obs, sim_metric)
         elif metric.lower() == "peak-timing":
-            values["Peak-Timing"] = mean_peak_timing(obs, sim, resolution=resolution, datetime_coord=datetime_coord)
+            values["Peak-Timing"] = mean_peak_timing(obs,
+                                                     sim_metric,
+                                                     resolution=resolution,
+                                                     datetime_coord=datetime_coord)
         elif metric.lower() == "missed-peaks":
-            values["Missed-Peaks"] = missed_peaks(obs, sim, resolution=resolution, datetime_coord=datetime_coord)
+            values["Missed-Peaks"] = missed_peaks(obs,
+                                                  sim_metric,
+                                                  resolution=resolution,
+                                                  datetime_coord=datetime_coord)
         elif metric.lower() == "peak-mape":
-            values["Peak-MAPE"] = mean_absolute_percentage_peak_error(obs, sim)
+            values["Peak-MAPE"] = mean_absolute_percentage_peak_error(obs, sim_metric)
+        elif metric.lower() == "crps":
+            values["CRPS"] = crps(obs, sim_metric)
+        elif metric.lower() == "picp":
+            values["PICP"] = picp(obs, sim_metric)
+        elif metric.lower() == "mpiw":
+            values["MPIW"] = mpiw(obs, sim_metric)
         else:
             raise RuntimeError(f"Unknown metric {metric}")
 
@@ -882,7 +1042,7 @@ def _check_all_nan(obs: DataArray, sim: DataArray):
     AllNaNError
         If all observations or all simulations are NaN.
     """
-    if all(obs.isnull()):
+    if obs.isnull().all():
         raise AllNaNError("All observed values are NaN, thus metrics will be NaN, too.")
-    if all(sim.isnull()):
+    if sim.isnull().all():
         raise AllNaNError("All simulated values are NaN, thus metrics will be NaN, too.")

--- a/neuralhydrology/evaluation/metrics.py
+++ b/neuralhydrology/evaluation/metrics.py
@@ -10,6 +10,7 @@ from neuralhydrology.datautils import utils
 from neuralhydrology.utils.errors import AllNaNError
 
 LOGGER = logging.getLogger(__name__)
+_PROBABILISTIC_METRICS = ("CRPS", "PICP", "MPIW")
 
 
 def get_available_metrics(include_probabilistic: bool = False) -> List[str]:
@@ -30,7 +31,7 @@ def get_available_metrics(include_probabilistic: bool = False) -> List[str]:
         "Peak-Timing", "Missed-Peaks", "Peak-MAPE"
     ]
     if include_probabilistic:
-        metrics += ["CRPS", "PICP", "MPIW"]
+        metrics += list(_PROBABILISTIC_METRICS)
     return metrics
 
 
@@ -63,7 +64,7 @@ def _validate_ensemble_inputs(obs: DataArray, sim: DataArray):
 
 
 def _mask_valid_ensemble(obs: DataArray, sim: DataArray) -> Tuple[DataArray, DataArray]:
-    idx = (~obs.isnull()) & sim.notnull().all(dim='samples')
+    idx = obs.notnull() & sim.notnull().all(dim='samples')
 
     obs = obs[idx]
     sim = sim.where(idx, drop=True)
@@ -848,8 +849,7 @@ def picp(obs: DataArray, sim: DataArray, alpha: float = 0.1) -> float:
     if len(obs) < 1:
         return np.nan
 
-    lower = sim.quantile(alpha / 2, dim='samples')
-    upper = sim.quantile(1 - alpha / 2, dim='samples')
+    lower, upper = sim.quantile([alpha / 2, 1 - alpha / 2], dim='samples')
 
     coverage = (obs >= lower) & (obs <= upper)
     return float(coverage.mean())
@@ -884,8 +884,7 @@ def mpiw(obs: DataArray, sim: DataArray, alpha: float = 0.1) -> float:
     if len(obs) < 1:
         return np.nan
 
-    lower = sim.quantile(alpha / 2, dim='samples')
-    upper = sim.quantile(1 - alpha / 2, dim='samples')
+    lower, upper = sim.quantile([alpha / 2, 1 - alpha / 2], dim='samples')
 
     return float((upper - lower).mean())
 
@@ -919,7 +918,8 @@ def calculate_all_metrics(obs: DataArray,
     """
     _check_all_nan(obs, sim)
 
-    sim_mean = sim.mean(dim='samples') if 'samples' in sim.dims else sim
+    has_samples = 'samples' in sim.dims
+    sim_mean = sim.mean(dim='samples') if has_samples else sim
 
     results = {
         "NSE": nse(obs, sim_mean),
@@ -938,7 +938,7 @@ def calculate_all_metrics(obs: DataArray,
         "Peak-MAPE": mean_absolute_percentage_peak_error(obs, sim_mean)
     }
 
-    if 'samples' in sim.dims:
+    if has_samples:
         results.update({
             "CRPS": crps(obs, sim),
             "PICP": picp(obs, sim),
@@ -983,50 +983,52 @@ def calculate_metrics(obs: DataArray,
 
     _check_all_nan(obs, sim)
 
+    has_samples = 'samples' in sim.dims
+    sim_mean = sim.mean(dim='samples') if has_samples else sim
+
     values = {}
     for metric in metrics:
-        sim_metric = sim.mean(dim='samples') if 'samples' in sim.dims and metric.lower() not in [
-            'crps', 'picp', 'mpiw'
-        ] else sim
-        if metric.lower() == "nse":
+        metric_name = metric.lower()
+        sim_metric = sim if metric.upper() in _PROBABILISTIC_METRICS else sim_mean
+        if metric_name == "nse":
             values["NSE"] = nse(obs, sim_metric)
-        elif metric.lower() == "mse":
+        elif metric_name == "mse":
             values["MSE"] = mse(obs, sim_metric)
-        elif metric.lower() == "rmse":
+        elif metric_name == "rmse":
             values["RMSE"] = rmse(obs, sim_metric)
-        elif metric.lower() == "kge":
+        elif metric_name == "kge":
             values["KGE"] = kge(obs, sim_metric)
-        elif metric.lower() == "alpha-nse":
+        elif metric_name == "alpha-nse":
             values["Alpha-NSE"] = alpha_nse(obs, sim_metric)
-        elif metric.lower() == "beta-kge":
+        elif metric_name == "beta-kge":
             values["Beta-KGE"] = beta_kge(obs, sim_metric)
-        elif metric.lower() == "beta-nse":
+        elif metric_name == "beta-nse":
             values["Beta-NSE"] = beta_nse(obs, sim_metric)
-        elif metric.lower() == "pearson-r":
+        elif metric_name == "pearson-r":
             values["Pearson-r"] = pearsonr(obs, sim_metric)
-        elif metric.lower() == "fhv":
+        elif metric_name == "fhv":
             values["FHV"] = fdc_fhv(obs, sim_metric)
-        elif metric.lower() == "fms":
+        elif metric_name == "fms":
             values["FMS"] = fdc_fms(obs, sim_metric)
-        elif metric.lower() == "flv":
+        elif metric_name == "flv":
             values["FLV"] = fdc_flv(obs, sim_metric)
-        elif metric.lower() == "peak-timing":
+        elif metric_name == "peak-timing":
             values["Peak-Timing"] = mean_peak_timing(obs,
                                                      sim_metric,
                                                      resolution=resolution,
                                                      datetime_coord=datetime_coord)
-        elif metric.lower() == "missed-peaks":
+        elif metric_name == "missed-peaks":
             values["Missed-Peaks"] = missed_peaks(obs,
                                                   sim_metric,
                                                   resolution=resolution,
                                                   datetime_coord=datetime_coord)
-        elif metric.lower() == "peak-mape":
+        elif metric_name == "peak-mape":
             values["Peak-MAPE"] = mean_absolute_percentage_peak_error(obs, sim_metric)
-        elif metric.lower() == "crps":
+        elif metric_name == "crps":
             values["CRPS"] = crps(obs, sim_metric)
-        elif metric.lower() == "picp":
+        elif metric_name == "picp":
             values["PICP"] = picp(obs, sim_metric)
-        elif metric.lower() == "mpiw":
+        elif metric_name == "mpiw":
             values["MPIW"] = mpiw(obs, sim_metric)
         else:
             raise RuntimeError(f"Unknown metric {metric}")

--- a/neuralhydrology/evaluation/tester.py
+++ b/neuralhydrology/evaluation/tester.py
@@ -30,6 +30,10 @@ from neuralhydrology.utils.errors import AllNaNError, NoEvaluationDataError
 LOGGER = logging.getLogger(__name__)
 
 
+def _has_samples(sim: xarray.DataArray) -> bool:
+    return 'samples' in sim.dims
+
+
 class BaseTester(object):
     """Base class to run inference on a model.
 
@@ -315,7 +319,7 @@ class BaseTester(object):
 
                             var_metrics = metrics if isinstance(metrics, list) else metrics[target_variable]
                             if 'all' in var_metrics:
-                                var_metrics = get_available_metrics(include_probabilistic=self._has_samples(sim))
+                                var_metrics = get_available_metrics(include_probabilistic=_has_samples(sim))
                             try:
                                 values = calculate_metrics(obs, sim, metrics=var_metrics, resolution=freq)
                             except AllNaNError as err:
@@ -417,23 +421,16 @@ class BaseTester(object):
                 pickle.dump(states, fp)
             LOGGER.info(f"Stored states at {result_file}")
 
-    @staticmethod
-    def _has_samples(sim: xarray.DataArray) -> bool:
-        return 'samples' in sim.dims
-
     def _has_sample_results(self, results: Optional[dict]) -> bool:
         if not results:
             return False
-        for basin_data in results.values():
-            for freq_results in basin_data.values():
-                xr = freq_results.get('xr')
-                if xr is None:
-                    continue
-                for target_var in self.cfg.target_variables:
-                    sim_key = f"{target_var}_sim"
-                    if sim_key in xr and self._has_samples(xr[sim_key]):
-                        return True
-        return False
+        basin_data = next(iter(results.values()))
+        if not basin_data or not self.cfg.target_variables:
+            return False
+        freq_results = next(iter(basin_data.values()))
+        ds = freq_results["xr"]
+        sim_key = f"{self.cfg.target_variables[0]}_sim"
+        return _has_samples(ds[sim_key])
 
     def _evaluate(self, model: BaseModel, loader: DataLoader, frequencies: List[str], save_all_output: bool = False):
         """Evaluate model"""

--- a/neuralhydrology/evaluation/tester.py
+++ b/neuralhydrology/evaluation/tester.py
@@ -313,12 +313,9 @@ class BaseTester(object):
                             if target_variable in self.cfg.clip_targets_to_zero:
                                 sim = xarray.where(sim < 0, 0, sim)
 
-                            if 'samples' in sim.dims:
-                                sim = sim.mean(dim='samples')
-
                             var_metrics = metrics if isinstance(metrics, list) else metrics[target_variable]
                             if 'all' in var_metrics:
-                                var_metrics = get_available_metrics()
+                                var_metrics = get_available_metrics(include_probabilistic=self._has_samples(sim))
                             try:
                                 values = calculate_metrics(obs, sim, metrics=var_metrics, resolution=freq)
                             except AllNaNError as err:
@@ -400,7 +397,7 @@ class BaseTester(object):
             if isinstance(metrics_list, dict):
                 metrics_list = list(set(metrics_list.values()))
             if "all" in metrics_list:
-                metrics_list = get_available_metrics()
+                metrics_list = get_available_metrics(include_probabilistic=self._has_sample_results(results))
             df = metrics_to_dataframe(results, metrics_list, self.cfg.target_variables)
             metrics_file = parent_directory / f"{self.period}_metrics.csv"
             df.to_csv(metrics_file)
@@ -419,6 +416,24 @@ class BaseTester(object):
             with result_file.open("wb") as fp:
                 pickle.dump(states, fp)
             LOGGER.info(f"Stored states at {result_file}")
+
+    @staticmethod
+    def _has_samples(sim: xarray.DataArray) -> bool:
+        return 'samples' in sim.dims
+
+    def _has_sample_results(self, results: Optional[dict]) -> bool:
+        if not results:
+            return False
+        for basin_data in results.values():
+            for freq_results in basin_data.values():
+                xr = freq_results.get('xr')
+                if xr is None:
+                    continue
+                for target_var in self.cfg.target_variables:
+                    sim_key = f"{target_var}_sim"
+                    if sim_key in xr and self._has_samples(xr[sim_key]):
+                        return True
+        return False
 
     def _evaluate(self, model: BaseModel, loader: DataLoader, frequencies: List[str], save_all_output: bool = False):
         """Evaluate model"""

--- a/test/test_configs/daily_uncertainty.test.yml
+++ b/test/test_configs/daily_uncertainty.test.yml
@@ -26,6 +26,9 @@ metrics:
   - KGE
   - Alpha-NSE
   - Beta-NSE
+  - CRPS
+  - PICP
+  - MPIW
 
 # --- Model configuration --------------------------------------------------------------------------
 model: cudalstm

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -55,6 +55,28 @@ def test_calculate_all_metrics_includes_ensemble_metrics_for_samples():
     assert metrics['MPIW'] == pytest.approx(1.8)
 
 
+def test_calculate_all_metrics_excludes_ensemble_metrics_without_samples():
+    dates = pd.date_range('2000-01-01', periods=4)
+    obs = xarray.DataArray([1.0, 2.0, 3.0, 4.0], dims=['date'], coords={'date': dates})
+    sim = xarray.DataArray([1.0, 2.0, 3.0, 4.0], dims=['date'], coords={'date': dates})
+
+    metrics = calculate_all_metrics(obs, sim, datetime_coord='date')
+
+    assert set(metrics) == set(get_available_metrics())
+
+
+@pytest.mark.parametrize('metric', [crps, picp, mpiw])
+@pytest.mark.parametrize('obs_values, sim_values', [
+    ([np.nan, np.nan], [[1.0, 2.0], [2.0, 3.0]]),
+    ([1.0, 2.0], [[np.nan, np.nan], [np.nan, np.nan]]),
+])
+def test_ensemble_metrics_return_nan_when_masking_removes_all_values(metric, obs_values, sim_values):
+    obs = xarray.DataArray(obs_values, dims=['datetime'])
+    sim = xarray.DataArray(sim_values, dims=['datetime', 'samples'])
+
+    assert np.isnan(metric(obs, sim))
+
+
 def test_available_metrics_only_include_probabilistic_metrics_on_request():
     assert 'CRPS' not in get_available_metrics()
     assert 'CRPS' in get_available_metrics(include_probabilistic=True)

--- a/test/test_metrics.py
+++ b/test/test_metrics.py
@@ -1,0 +1,60 @@
+import numpy as np
+import pandas as pd
+import pytest
+import xarray
+
+from neuralhydrology.evaluation.metrics import (calculate_all_metrics, calculate_metrics, crps, get_available_metrics,
+                                                mpiw, picp)
+
+
+def test_ensemble_metrics():
+    obs = xarray.DataArray([1.0, 2.0], dims=['datetime'])
+    sim = xarray.DataArray([[0.0, 2.0], [1.0, 3.0]], dims=['datetime', 'samples'])
+
+    assert crps(obs, sim) == pytest.approx(0.5)
+    assert picp(obs, sim, alpha=0.1) == pytest.approx(1.0)
+    assert mpiw(obs, sim, alpha=0.1) == pytest.approx(1.8)
+
+
+def test_ensemble_metrics_ignore_invalid_samples():
+    obs = xarray.DataArray([1.0, 2.0], dims=['datetime'])
+    sim = xarray.DataArray([[0.0, 2.0], [np.nan, 3.0]], dims=['datetime', 'samples'])
+
+    assert crps(obs, sim) == pytest.approx(0.5)
+    assert picp(obs, sim) == pytest.approx(1.0)
+    assert mpiw(obs, sim) == pytest.approx(1.8)
+
+
+def test_calculate_metrics_mixes_deterministic_and_ensemble_metrics():
+    obs = xarray.DataArray([1.0, 2.0], dims=['datetime'])
+    sim = xarray.DataArray([[0.0, 2.0], [1.0, 3.0]], dims=['datetime', 'samples'])
+
+    metrics = calculate_metrics(obs, sim, metrics=['MSE', 'CRPS', 'PICP', 'MPIW'])
+
+    assert metrics['MSE'] == pytest.approx(0.0)
+    assert metrics['CRPS'] == pytest.approx(0.5)
+    assert metrics['PICP'] == pytest.approx(1.0)
+    assert metrics['MPIW'] == pytest.approx(1.8)
+
+
+def test_calculate_all_metrics_includes_ensemble_metrics_for_samples():
+    dates = pd.date_range('2000-01-01', periods=4)
+    obs = xarray.DataArray([1.0, 2.0, 3.0, 4.0], dims=['date'], coords={'date': dates})
+    sim = xarray.DataArray([[0.0, 2.0], [1.0, 3.0], [2.0, 4.0], [3.0, 5.0]],
+                           dims=['date', 'samples'],
+                           coords={
+                               'date': dates,
+                               'samples': [0, 1]
+                           })
+
+    metrics = calculate_all_metrics(obs, sim, datetime_coord='date')
+
+    assert metrics['MSE'] == pytest.approx(0.0)
+    assert metrics['CRPS'] == pytest.approx(0.5)
+    assert metrics['PICP'] == pytest.approx(1.0)
+    assert metrics['MPIW'] == pytest.approx(1.8)
+
+
+def test_available_metrics_only_include_probabilistic_metrics_on_request():
+    assert 'CRPS' not in get_available_metrics()
+    assert 'CRPS' in get_available_metrics(include_probabilistic=True)


### PR DESCRIPTION
## Summary
- Add sample-based CRPS, PICP, and MPIW metrics for probabilistic forecasts.
- Preserve deterministic metric behavior by evaluating existing metrics on the sample mean.
- Expand metrics: all to include probabilistic metrics only when sample predictions are present.
- Add metric unit tests and uncertainty smoke-test coverage.

## Tests
- python -m pytest test/test_metrics.py -q
- python -m pytest test/test_mclstm.py test/test_custom_lstm.py -q
- python -m pytest test/test_uncertainty.py -q --smoke-test
